### PR TITLE
Boost 1.42.0

### DIFF
--- a/recipes/boost/1.42.0/boost_glibc_2_17_cstdint.patch
+++ b/recipes/boost/1.42.0/boost_glibc_2_17_cstdint.patch
@@ -1,0 +1,11 @@
+--- ./boost/cstdint.hpp	2009-12-14 18:14:48.000000000 +0000
++++ ./cstdint.hpp	2018-04-01 21:51:57.717360193 +0100
+@@ -41,7 +41,7 @@
+ // so we disable use of stdint.h when GLIBC does not define __GLIBC_HAVE_LONG_LONG.
+ // See https://svn.boost.org/trac/boost/ticket/3548 and http://sources.redhat.com/bugzilla/show_bug.cgi?id=10990
+ //
+-#if defined(BOOST_HAS_STDINT_H) && (!defined(__GLIBC__) || defined(__GLIBC_HAVE_LONG_LONG))
++#if defined(BOOST_HAS_STDINT_H) && (!defined(__GLIBC__) || (defined(__GLIBC_HAVE_LONG_LONG)) || __GLIBC_PREREQ(2, 17))
+ 
+ // The following #include is an implementation artifact; not part of interface.
+ # ifdef __hpux

--- a/recipes/boost/1.42.0/boost_time_utc_timeconv.patch
+++ b/recipes/boost/1.42.0/boost_time_utc_timeconv.patch
@@ -1,0 +1,46 @@
+--- ./libs/thread/src/pthread/timeconv.inl	2007-11-25 18:38:02.000000000 +0000
++++ ./timeconv.inl	2018-04-01 00:09:41.901238264 +0100
+@@ -17,8 +17,8 @@
+ inline void to_time(int milliseconds, boost::xtime& xt)
+ {
+     int res = 0;
+-    res = boost::xtime_get(&xt, boost::TIME_UTC);
+-    assert(res == boost::TIME_UTC);
++    res = boost::xtime_get(&xt, boost::TIME_UTC_);
++    assert(res == boost::TIME_UTC_);
+ 
+     xt.sec += (milliseconds / MILLISECONDS_PER_SECOND);
+     xt.nsec += ((milliseconds % MILLISECONDS_PER_SECOND) *
+@@ -54,8 +54,8 @@
+ {
+     boost::xtime cur;
+     int res = 0;
+-    res = boost::xtime_get(&cur, boost::TIME_UTC);
+-    assert(res == boost::TIME_UTC);
++    res = boost::xtime_get(&cur, boost::TIME_UTC_);
++    assert(res == boost::TIME_UTC_);
+ 
+     if (boost::xtime_cmp(xt, cur) <= 0)
+     {
+@@ -85,8 +85,8 @@
+ {
+     boost::xtime cur;
+     int res = 0;
+-    res = boost::xtime_get(&cur, boost::TIME_UTC);
+-    assert(res == boost::TIME_UTC);
++    res = boost::xtime_get(&cur, boost::TIME_UTC_);
++    assert(res == boost::TIME_UTC_);
+ 
+     if (boost::xtime_cmp(xt, cur) <= 0)
+         milliseconds = 0;
+@@ -107,8 +107,8 @@
+ {
+     boost::xtime cur;
+     int res = 0;
+-    res = boost::xtime_get(&cur, boost::TIME_UTC);
+-    assert(res == boost::TIME_UTC);
++    res = boost::xtime_get(&cur, boost::TIME_UTC_);
++    assert(res == boost::TIME_UTC_);
+ 
+     if (boost::xtime_cmp(xt, cur) <= 0)
+         microseconds = 0;

--- a/recipes/boost/1.42.0/boost_time_utc_xtime.patch
+++ b/recipes/boost/1.42.0/boost_time_utc_xtime.patch
@@ -1,0 +1,20 @@
+--- boost/thread/xtime.hpp	2008-06-18 14:01:08.000000000 +0100
++++ ./xtime.hpp	2018-04-01 00:08:35.625550741 +0100
+@@ -20,7 +20,7 @@
+ 
+ enum xtime_clock_types
+ {
+-    TIME_UTC=1
++    TIME_UTC_=1
+ //    TIME_TAI,
+ //    TIME_MONOTONIC,
+ //    TIME_PROCESS,
+@@ -68,7 +68,7 @@
+ 
+ inline int xtime_get(struct xtime* xtp, int clock_type)
+ {
+-    if (clock_type == TIME_UTC)
++    if (clock_type == TIME_UTC_)
+     {
+         *xtp=get_xtime(get_system_time());
+         return clock_type;

--- a/recipes/boost/1.42.0/build.sh
+++ b/recipes/boost/1.42.0/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+n=$CPU_COUNT
+
+./bootstrap.sh --prefix="$PREFIX" 
+
+./bjam -j $n --prefix="$PREFIX" --without-mpi -q install

--- a/recipes/boost/1.42.0/meta.yaml
+++ b/recipes/boost/1.42.0/meta.yaml
@@ -1,0 +1,52 @@
+{% set version = "1.42.0" %}
+{% set alt_version = "1_42_0" %}
+{% set sha256 = "4b1eb95bd250ce15ac66435d6167f225b072b0d3a7eb72477a31847a9ca9e609" %}
+
+package:
+  name: boost
+  version: "{{ version }}"
+
+about:
+  home: http://www.boost.org
+  license: Boost
+  summary: "Free peer-reviewed portable C++ source libraries."
+
+build:
+  number: 0
+
+  rpaths:
+    - lib64
+    - lib
+
+source:
+  url: https://sourceforge.net/projects/boost/files/boost/{{ version }}/boost_{{ alt_version }}.tar.bz2/download
+  fn: boost_{{ alt_version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+  patches:
+    # __GLIBC_HAVE_LONG_LONG define has been dropped from glibc in 2.17.
+    # See https://svn.boost.org/trac10/ticket/8731
+    - boost_glibc_2_17_cstdint.patch
+    # TIME_UTC is a macro in C11. See https://svn.boost.org/trac10/ticket/6940
+    - boost_time_utc_timeconv.patch
+    # TIME_UTC is a macro in C11. See https://svn.boost.org/trac10/ticket/6940
+    - boost_time_utc_xtime.patch
+
+requirements:
+  build:
+    - bzip2
+    - gcc_npg >=4.6,<5.0
+    - xz
+    - zlib
+
+  run:
+    - bzip2
+    - libgcc_npg >=4.6,<5.0
+    - xz
+    - zlib
+
+test:
+  commands:
+    - test -f ${PREFIX}/include/boost/config.hpp
+    - test -f ${PREFIX}/lib/libboost_system.a
+    - test -h ${PREFIX}/lib/libboost_system.so


### PR DESCRIPTION
Boost 1.42.0 (required by some older bioinformatics tools) patched to compile with more recent gcc/glibc.