### PR TITLE
add bin/node to ignore_prefix_files

### DIFF
--- a/recipes/nodejs/6.12.2/meta.yaml
+++ b/recipes/nodejs/6.12.2/meta.yaml
@@ -15,6 +15,11 @@ source:
   fn: node-v{{ version }}-linux-x64.tar.gz
   sha256: {{ sha256 }}
 
+build:
+  number: 1
+  ignore_prefix_files:
+    - bin/node
+
 requirements:
   build:
     - python 2.7.*


### PR DESCRIPTION
To fix problem with node not finding its own libraries.

From https://github.com/conda-forge/nodejs-feedstock/blob/6.x/recipe/meta.yaml