### PR TITLE
Added the binary release package of wr.

### DIFF
--- a/recipes/wr/0.11.0/build.sh
+++ b/recipes/wr/0.11.0/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+mkdir -p "$PREFIX/bin"
+cp wr "$PREFIX/bin/"
+
+mkdir -p "$PREFIX/etc"
+cp wr_config.yml "$PREFIX/etc/"
+
+mkdir -p "$PREFIX/share/doc/wr"
+cp README.md "$PREFIX/share/doc/wr/"

--- a/recipes/wr/0.11.0/meta.yaml
+++ b/recipes/wr/0.11.0/meta.yaml
@@ -1,0 +1,24 @@
+{% set version = "0.11.0" %}
+{% set sha256 = "eaa92e6f53b65c1065efadddca79160dbdabd307283ef3337155d22c01081104" %}
+
+package:
+  name: wr
+  version: "{{ version }}"
+
+about:
+  home: https://github.com/VertebrateResequencing/wr
+  license: GPLv3
+  summary: "High performance Workflow Runner."
+
+build:
+  number: 0
+  binary_relocation: false
+
+source:
+  url: https://github.com/VertebrateResequencing/wr/releases/download/v{{ version }}/wr-linux-x86-64.zip
+  fn: wr-{{ version }}.zip
+  sha256: {{ sha256 }}
+
+test:
+  commands:
+    - wr -h


### PR DESCRIPTION
Using this avoids the need for creating a golang package. It solves the immediate block of having a Conda package for wr.

(Building wr from source is a lot more work because Conda has some problems with packaging the binary dist of golang. The latter contains files which I find crash the Python linkage analyser. If we build golang from source too, that's even more work because it needs to be bootstrapped.)