### PR TITLE
Split curl into executable and library/header packages.

### DIFF
--- a/recipes/curl/7.58.0/build.sh
+++ b/recipes/curl/7.58.0/build.sh
@@ -4,6 +4,10 @@ set -e
 
 n=`expr $CPU_COUNT / 4 \| 1`
 
-./configure prefix="$PREFIX" --with-zlib="$PREFIX" CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
+./configure prefix="$PREFIX" \
+            --with-gnutls="$PREFIX" \
+            --with-zlib="$PREFIX" \
+            --without-ssl \
+            CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
 make -j $n
 make install prefix="$PREFIX"

--- a/recipes/curl/7.58.0/meta.yaml
+++ b/recipes/curl/7.58.0/meta.yaml
@@ -11,7 +11,7 @@ about:
   summary: Command line tool and library for transferring data with URLs.
 
 build:
-  number: 0
+  number: 1
 
 source:
   - url: http://curl.haxx.se/download/curl-{{ version }}.tar.bz2
@@ -21,14 +21,37 @@ source:
 requirements:
   build:
     - gcc_npg >=7.3
+    - gnutls
     - zlib
 
-  run:
-    - zlib
+outputs:
+  - name: curl
+    version: {{ version }}
+    requirements:
+      run:
+        - libcurl =={{ version}}
+    files:
+      - bin/curl
+      - bin/curl-config
+      - share/man/man1/curl.1
+      - share/man/man1/curl-config.1
+    test:
+      commands:
+        - curl -h
 
-test:
-  commands:
-    - curl -h
-    - test -f ${PREFIX}/include/curl/curl.h
-    - test -f ${PREFIX}/lib/libcurl.a
-    - test -h ${PREFIX}/lib/libcurl.so
+  - name: libcurl
+    version: {{ version }}
+    requirements:
+      run:
+        - gnutls
+        - zlib
+    files:
+      - include/curl
+      - lib/libcurl*
+      - lib/pkgconfig/libcurl.pc
+      - share/man/man4/libcurl*
+    test:
+      commands:
+        - test -f ${PREFIX}/include/curl/curl.h
+        - test -f ${PREFIX}/lib/libcurl.a
+        - test -h ${PREFIX}/lib/libcurl.so

--- a/recipes/gmplib/6.1.2/build.sh
+++ b/recipes/gmplib/6.1.2/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+n=`expr $CPU_COUNT / 4 \| 1`
+
+./configure --prefix="$PREFIX"
+make -j $n
+make install prefix="$PREFIX"

--- a/recipes/gmplib/6.1.2/meta.yaml
+++ b/recipes/gmplib/6.1.2/meta.yaml
@@ -1,0 +1,32 @@
+{% set version = "6.1.2" %}
+{% set sha256 = "87b565e89a9a684fe4ebeeddb8399dce2599f9c9049854ca8c0dfbdea0e21912" %}
+
+package:
+  name: gmplib
+  version: "{{ version }}"
+
+about:
+  home: https://gmplib.org/
+  license: 
+  summary: "The GNU Multiple Precision Arithmetic Library."
+
+build:
+  number: 0
+
+source:
+  url: https://gmplib.org/download/gmp/gmp-{{ version }}.tar.xz
+  fn: gmplib-{{ version }}.tar.xz
+  sha256: {{ sha256 }}
+
+requirements:
+  build:
+    - gcc_npg >=7.3
+    - zlib
+
+  run:
+    - zlib
+
+test:
+  commands:
+    - test -f ${PREFIX}/lib/libgmp.a
+    - test -f ${PREFIX}/lib/libgmp.so

--- a/recipes/gnutls/3.4.17/build.sh
+++ b/recipes/gnutls/3.4.17/build.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+n=`expr $CPU_COUNT / 4 \| 1`
+
+./configure --prefix="$PREFIX" \
+            --with-included-libtasn1 \
+            --with-included-unistring \
+            --with-zlib-prefix="$PREFIX" \
+            --without-idn \
+            --without-p11-kit \
+            --without-tpm
+make -j $n
+make install prefix="$PREFIX"

--- a/recipes/gnutls/3.4.17/meta.yaml
+++ b/recipes/gnutls/3.4.17/meta.yaml
@@ -1,0 +1,37 @@
+{% set version = "3.4.17" %}
+{% set short_version = "3.4" %}
+{% set sha256 = "9b50e8a670d5e950425d96935c7ddd415eb6f8079615a36df425f09a3143172e" %}
+
+package:
+  name: gnutls
+  version: "{{ version }}"
+
+about:
+  home: https://gnutls.org/
+  license: LGPL
+  summary: "The GnuTLS Transport Layer Security Library."
+
+build:
+  number: 0
+
+source:
+  - url: https://www.gnupg.org/ftp/gcrypt/gnutls/v{{ short_version }}/gnutls-{{ version }}.tar.xz
+    fn: gnutls-{{ version }}.tar.xz
+    sha256: {{ sha256 }}
+
+requirements:
+  build:
+    - gcc_npg >=7.3
+    - gmplib
+    - nettle
+    - zlib
+
+  run:
+    - libgcc_npg
+    - gmplib
+    - nettle
+    - zlib
+
+test:
+  commands:
+    - gnutls-cli -h

--- a/recipes/htslib/1.5/meta.yaml
+++ b/recipes/htslib/1.5/meta.yaml
@@ -12,7 +12,7 @@ about:
   summary: C library for high-throughput sequencing data formats.
 
 build:
-  number: 0
+  number: 1
   string: plugins_{{ plugins_rev }}_{{ PKG_BUILDNUM }}
   
 source:
@@ -29,7 +29,7 @@ features:
 requirements:
   build:
     - bzip2
-    - curl
+    - libcurl
     - gcc_npg >=7.3
     - irods-dev # for plugins
     - xz
@@ -37,7 +37,7 @@ requirements:
 
   run:
     - bzip2
-    - curl
+    - libcurl
     - xz
     - zlib
 

--- a/recipes/htslib/1.6/meta.yaml
+++ b/recipes/htslib/1.6/meta.yaml
@@ -12,7 +12,7 @@ about:
   summary: C library for high-throughput sequencing data formats.
 
 build:
-  number: 0
+  number: 1
   string: plugins_{{ plugins_rev }}_{{ PKG_BUILDNUM }}
 
 source:
@@ -29,7 +29,7 @@ features:
 requirements:
   build:
     - bzip2
-    - curl
+    - libcurl
     - gcc_npg >=7.3
     - irods-dev # for plugins
     - xz
@@ -37,7 +37,7 @@ requirements:
 
   run:
     - bzip2
-    - curl
+    - libcurl
     - xz
     - zlib
 

--- a/recipes/htslib/1.7/meta.yaml
+++ b/recipes/htslib/1.7/meta.yaml
@@ -12,7 +12,7 @@ about:
   summary: C library for high-throughput sequencing data formats.
 
 build:
-  number: 0
+  number: 1
   string: plugins_{{ plugins_rev }}_{{ PKG_BUILDNUM }}
 
 source:
@@ -29,7 +29,7 @@ features:
 requirements:
   build:
     - bzip2
-    - curl
+    - libcurl
     - gcc_npg >=7.3
     - irods-dev # for plugins
     - xz
@@ -37,7 +37,7 @@ requirements:
 
   run:
     - bzip2
-    - curl
+    - libcurl
     - xz
     - zlib
 

--- a/recipes/staden_io_lib/1.14.6/meta.yaml
+++ b/recipes/staden_io_lib/1.14.6/meta.yaml
@@ -11,7 +11,7 @@ about:
   summary: DNA sequence assembly, editing and analysis tools.
 
 build:
-  number: 0
+  number: 1
 
 source:
   url: https://sourceforge.net/projects/staden/files/io_lib/{{ version }}/io_lib-{{ version }}.tar.gz/download
@@ -21,14 +21,14 @@ source:
 requirements:
   build:
     - bzip2
-    - curl
+    - libcurl
     - gcc_npg >=7.3
     - xz
     - zlib
 
   run:
     - bzip2
-    - curl
+    - libcurl
     - xz
     - zlib
 

--- a/recipes/staden_io_lib/1.14.9/meta.yaml
+++ b/recipes/staden_io_lib/1.14.9/meta.yaml
@@ -11,7 +11,7 @@ about:
   summary: DNA sequence assembly, editing and analysis tools.
 
 build:
-  number: 0
+  number: 1
 
 source:
   url: https://sourceforge.net/projects/staden/files/io_lib/{{ version }}/io_lib-{{ version }}.tar.gz/download
@@ -21,14 +21,14 @@ source:
 requirements:
   build:
     - bzip2
-    - curl
+    - libcurl
     - gcc_npg >=7.3
     - xz
     - zlib
 
   run:
     - bzip2
-    - curl
+    - libcurl
     - xz
     - zlib
 


### PR DESCRIPTION
Split curl into executable and library/header packages. Updated packages that depend on the library package. Now configured with gnutls instread of openssl.