### PR TITLE
Split bzip2 into executable and library/header packages.

### DIFF
--- a/recipes/boost/1.42.0/meta.yaml
+++ b/recipes/boost/1.42.0/meta.yaml
@@ -12,7 +12,7 @@ about:
   summary: "Free peer-reviewed portable C++ source libraries."
 
 build:
-  number: 0
+  number: 1
 
   rpaths:
     - lib64
@@ -34,13 +34,13 @@ source:
 
 requirements:
   build:
-    - bzip2
+    - libbzip2
     - gcc_npg >=4.6,<5.0
     - xz
     - zlib
 
   run:
-    - bzip2
+    - libbzip2
     - libgcc_npg >=4.6,<5.0
     - xz
     - zlib

--- a/recipes/boost/1.47.0/meta.yaml
+++ b/recipes/boost/1.47.0/meta.yaml
@@ -12,7 +12,7 @@ about:
   summary: "Free peer-reviewed portable C++ source libraries."
 
 build:
-  number: 0
+  number: 1
 
   rpaths:
     - lib64
@@ -25,13 +25,13 @@ source:
 
 requirements:
   build:
-    - bzip2
+    - libbzip2
     - gcc_npg >=4.6,<5.0
     - xz
     - zlib
 
   run:
-    - bzip2
+    - libbzip2
     - libgcc_npg >=4.6,<5.0
     - xz
     - zlib

--- a/recipes/boost/1.55.0/meta.yaml
+++ b/recipes/boost/1.55.0/meta.yaml
@@ -12,7 +12,7 @@ about:
   summary: "Free peer-reviewed portable C++ source libraries."
 
 build:
-  number: 0
+  number: 1
 
   rpaths:
     - lib64
@@ -25,13 +25,13 @@ source:
 
 requirements:
   build:
-    - bzip2
+    - libbzip2
     - gcc_npg >=4.6,<5.0
     - xz
     - zlib
 
   run:
-    - bzip2
+    - libbzip2
     - libgcc_npg >=4.6,<5.0
     - xz
     - zlib

--- a/recipes/boost/1.66.0/meta.yaml
+++ b/recipes/boost/1.66.0/meta.yaml
@@ -12,7 +12,7 @@ about:
   summary: "Free peer-reviewed portable C++ source libraries."
 
 build:
-  number: 0
+  number: 1
 
   rpaths:
     - lib64
@@ -25,13 +25,13 @@ source:
 
 requirements:
   build:
-    - bzip2
+    - libbzip2
     - gcc_npg >=7.3
     - xz
     - zlib
 
   run:
-    - bzip2
+    - libbzip2
     - libgcc_npg >=7.3
     - xz
     - zlib

--- a/recipes/bzip2/1.0.6/meta.yaml
+++ b/recipes/bzip2/1.0.6/meta.yaml
@@ -11,7 +11,7 @@ about:
   summary: Data compressor.
 
 build:
-  number: 0
+  number: 1
   
 source:
   url: http://bzip.org/{{ version }}/bzip2-{{ version }}.tar.gz
@@ -24,10 +24,37 @@ requirements:
   build:
     - gcc_npg >=7.3.0
 
-test:
-  commands:
-  - bzip2 --help
-  - bunzip2 --help
-  - test -f ${PREFIX}/include/bzlib.h
-  - test -f ${PREFIX}/lib/libbz2.a
-  - test -h ${PREFIX}/lib/libbz2.so.1.0
+outputs:
+  - name: bzip2
+    version: {{ version }}
+    requirements:
+      run:
+        - libbzip2 =={{ version }}
+    files:
+      - bin/bunzip2
+      - bin/bzcat
+      - bin/bzcmp
+      - bin/bzdiff
+      - bin/bzegrep
+      - bin/bzfgrep
+      - bin/bzgrep
+      - bin/bzip2
+      - bin/bziprecover
+      - bin/bzless
+      - bin/bzmore
+      - man/man1
+    test:
+      commands:
+        - bzip2 --help
+        - bunzip2 --help
+
+  - name: libbzip2
+    version: {{ version }}
+    files:
+      - include
+      - lib
+    test:
+      commands:
+        - test -f ${PREFIX}/include/bzlib.h
+        - test -f ${PREFIX}/lib/libbz2.a
+        - test -h ${PREFIX}/lib/libbz2.so.1.0

--- a/recipes/curl/7.58.0/build.sh
+++ b/recipes/curl/7.58.0/build.sh
@@ -4,6 +4,10 @@ set -e
 
 n=`expr $CPU_COUNT / 4 \| 1`
 
-./configure prefix="$PREFIX" --with-zlib="$PREFIX" CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
+./configure prefix="$PREFIX" \
+            --with-gnutls="$PREFIX" \
+            --with-zlib="$PREFIX" \
+            --without-ssl \
+            CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
 make -j $n
 make install prefix="$PREFIX"

--- a/recipes/curl/7.58.0/meta.yaml
+++ b/recipes/curl/7.58.0/meta.yaml
@@ -11,7 +11,7 @@ about:
   summary: Command line tool and library for transferring data with URLs.
 
 build:
-  number: 0
+  number: 1
 
 source:
   - url: http://curl.haxx.se/download/curl-{{ version }}.tar.bz2
@@ -21,14 +21,37 @@ source:
 requirements:
   build:
     - gcc_npg >=7.3
+    - gnutls
     - zlib
 
-  run:
-    - zlib
+outputs:
+  - name: curl
+    version: {{ version }}
+    requirements:
+      run:
+        - libcurl =={{ version}}
+    files:
+      - bin/curl
+      - bin/curl-config
+      - share/man/man1/curl.1
+      - share/man/man1/curl-config.1
+    test:
+      commands:
+        - curl -h
 
-test:
-  commands:
-    - curl -h
-    - test -f ${PREFIX}/include/curl/curl.h
-    - test -f ${PREFIX}/lib/libcurl.a
-    - test -h ${PREFIX}/lib/libcurl.so
+  - name: libcurl
+    version: {{ version }}
+    requirements:
+      run:
+        - gnutls
+        - zlib
+    files:
+      - include/curl
+      - lib/libcurl*
+      - lib/pkgconfig/libcurl.pc
+      - share/man/man4/libcurl*
+    test:
+      commands:
+        - test -f ${PREFIX}/include/curl/curl.h
+        - test -f ${PREFIX}/lib/libcurl.a
+        - test -h ${PREFIX}/lib/libcurl.so

--- a/recipes/gmplib/6.1.2/build.sh
+++ b/recipes/gmplib/6.1.2/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+n=`expr $CPU_COUNT / 4 \| 1`
+
+./configure --prefix="$PREFIX"
+make -j $n
+make install prefix="$PREFIX"

--- a/recipes/gmplib/6.1.2/meta.yaml
+++ b/recipes/gmplib/6.1.2/meta.yaml
@@ -1,0 +1,32 @@
+{% set version = "6.1.2" %}
+{% set sha256 = "87b565e89a9a684fe4ebeeddb8399dce2599f9c9049854ca8c0dfbdea0e21912" %}
+
+package:
+  name: gmplib
+  version: "{{ version }}"
+
+about:
+  home: https://gmplib.org/
+  license: 
+  summary: "The GNU Multiple Precision Arithmetic Library."
+
+build:
+  number: 0
+
+source:
+  url: https://gmplib.org/download/gmp/gmp-{{ version }}.tar.xz
+  fn: gmplib-{{ version }}.tar.xz
+  sha256: {{ sha256 }}
+
+requirements:
+  build:
+    - gcc_npg >=7.3
+    - zlib
+
+  run:
+    - zlib
+
+test:
+  commands:
+    - test -f ${PREFIX}/lib/libgmp.a
+    - test -f ${PREFIX}/lib/libgmp.so

--- a/recipes/gnutls/3.4.17/build.sh
+++ b/recipes/gnutls/3.4.17/build.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+n=`expr $CPU_COUNT / 4 \| 1`
+
+./configure --prefix="$PREFIX" \
+            --with-included-libtasn1 \
+            --with-included-unistring \
+            --with-zlib-prefix="$PREFIX" \
+            --without-idn \
+            --without-p11-kit \
+            --without-tpm
+make -j $n
+make install prefix="$PREFIX"

--- a/recipes/gnutls/3.4.17/meta.yaml
+++ b/recipes/gnutls/3.4.17/meta.yaml
@@ -1,0 +1,37 @@
+{% set version = "3.4.17" %}
+{% set short_version = "3.4" %}
+{% set sha256 = "9b50e8a670d5e950425d96935c7ddd415eb6f8079615a36df425f09a3143172e" %}
+
+package:
+  name: gnutls
+  version: "{{ version }}"
+
+about:
+  home: https://gnutls.org/
+  license: LGPL
+  summary: "The GnuTLS Transport Layer Security Library."
+
+build:
+  number: 0
+
+source:
+  - url: https://www.gnupg.org/ftp/gcrypt/gnutls/v{{ short_version }}/gnutls-{{ version }}.tar.xz
+    fn: gnutls-{{ version }}.tar.xz
+    sha256: {{ sha256 }}
+
+requirements:
+  build:
+    - gcc_npg >=7.3
+    - gmplib
+    - nettle
+    - zlib
+
+  run:
+    - libgcc_npg
+    - gmplib
+    - nettle
+    - zlib
+
+test:
+  commands:
+    - gnutls-cli -h

--- a/recipes/htslib/1.5/meta.yaml
+++ b/recipes/htslib/1.5/meta.yaml
@@ -12,7 +12,7 @@ about:
   summary: C library for high-throughput sequencing data formats.
 
 build:
-  number: 1
+  number: 2
   string: plugins_{{ plugins_rev }}_{{ PKG_BUILDNUM }}
   
 source:
@@ -28,7 +28,7 @@ features:
 
 requirements:
   build:
-    - bzip2
+    - libbzip2
     - libcurl
     - gcc_npg >=7.3
     - irods-dev # for plugins
@@ -36,7 +36,7 @@ requirements:
     - zlib
 
   run:
-    - bzip2
+    - libbzip2
     - libcurl
     - xz
     - zlib

--- a/recipes/htslib/1.5/meta.yaml
+++ b/recipes/htslib/1.5/meta.yaml
@@ -12,7 +12,7 @@ about:
   summary: C library for high-throughput sequencing data formats.
 
 build:
-  number: 0
+  number: 1
   string: plugins_{{ plugins_rev }}_{{ PKG_BUILDNUM }}
   
 source:
@@ -29,7 +29,7 @@ features:
 requirements:
   build:
     - bzip2
-    - curl
+    - libcurl
     - gcc_npg >=7.3
     - irods-dev # for plugins
     - xz
@@ -37,7 +37,7 @@ requirements:
 
   run:
     - bzip2
-    - curl
+    - libcurl
     - xz
     - zlib
 

--- a/recipes/htslib/1.6/meta.yaml
+++ b/recipes/htslib/1.6/meta.yaml
@@ -12,7 +12,7 @@ about:
   summary: C library for high-throughput sequencing data formats.
 
 build:
-  number: 0
+  number: 1
   string: plugins_{{ plugins_rev }}_{{ PKG_BUILDNUM }}
 
 source:
@@ -29,7 +29,7 @@ features:
 requirements:
   build:
     - bzip2
-    - curl
+    - libcurl
     - gcc_npg >=7.3
     - irods-dev # for plugins
     - xz
@@ -37,7 +37,7 @@ requirements:
 
   run:
     - bzip2
-    - curl
+    - libcurl
     - xz
     - zlib
 

--- a/recipes/htslib/1.6/meta.yaml
+++ b/recipes/htslib/1.6/meta.yaml
@@ -12,7 +12,7 @@ about:
   summary: C library for high-throughput sequencing data formats.
 
 build:
-  number: 1
+  number: 2
   string: plugins_{{ plugins_rev }}_{{ PKG_BUILDNUM }}
 
 source:
@@ -28,7 +28,7 @@ features:
 
 requirements:
   build:
-    - bzip2
+    - libbzip2
     - libcurl
     - gcc_npg >=7.3
     - irods-dev # for plugins
@@ -36,7 +36,7 @@ requirements:
     - zlib
 
   run:
-    - bzip2
+    - libbzip2
     - libcurl
     - xz
     - zlib

--- a/recipes/htslib/1.7/meta.yaml
+++ b/recipes/htslib/1.7/meta.yaml
@@ -12,7 +12,7 @@ about:
   summary: C library for high-throughput sequencing data formats.
 
 build:
-  number: 0
+  number: 1
   string: plugins_{{ plugins_rev }}_{{ PKG_BUILDNUM }}
 
 source:
@@ -29,7 +29,7 @@ features:
 requirements:
   build:
     - bzip2
-    - curl
+    - libcurl
     - gcc_npg >=7.3
     - irods-dev # for plugins
     - xz
@@ -37,7 +37,7 @@ requirements:
 
   run:
     - bzip2
-    - curl
+    - libcurl
     - xz
     - zlib
 

--- a/recipes/htslib/1.7/meta.yaml
+++ b/recipes/htslib/1.7/meta.yaml
@@ -12,7 +12,7 @@ about:
   summary: C library for high-throughput sequencing data formats.
 
 build:
-  number: 1
+  number: 2
   string: plugins_{{ plugins_rev }}_{{ PKG_BUILDNUM }}
 
 source:
@@ -28,7 +28,7 @@ features:
 
 requirements:
   build:
-    - bzip2
+    - libbzip2
     - libcurl
     - gcc_npg >=7.3
     - irods-dev # for plugins
@@ -36,7 +36,7 @@ requirements:
     - zlib
 
   run:
-    - bzip2
+    - libbzip2
     - libcurl
     - xz
     - zlib

--- a/recipes/nanopolish/0.8.5/meta.yaml
+++ b/recipes/nanopolish/0.8.5/meta.yaml
@@ -10,7 +10,7 @@ about:
   summary: "Software package for signal-level analysis of Oxford Nanopore sequencing data."
 
 build:
-  number: 0
+  number: 1
 
   rpaths:
     - lib64
@@ -24,7 +24,7 @@ source:
 
 requirements:
   build:
-    - bzip2
+    - libbzip2
     - eigen
     - gcc_npg >=7.3
     - hdf5
@@ -33,7 +33,7 @@ requirements:
     - zlib
 
   run:
-    - bzip2
+    - libbzip2
     - hdf5
     - htslib >=1.7
     - libgcc_npg >=7.3

--- a/recipes/olb/1.9.4/meta.yaml
+++ b/recipes/olb/1.9.4/meta.yaml
@@ -17,7 +17,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
 
   rpaths:
     - lib64
@@ -26,7 +26,7 @@ build:
 requirements:
   build:
     - boost ==1.42.0
-    - bzip2
+    - libbzip2
     - fftw
     - gcc_npg ==4.6.4
     - zlib

--- a/recipes/pcre/8.41/meta.yaml
+++ b/recipes/pcre/8.41/meta.yaml
@@ -11,7 +11,7 @@ about:
   summary: "Perl Compatible Regular Expressions."
 
 build:
-  number: 0
+  number: 1
   
 source:
   url: https://ftp.pcre.org/pub/pcre/pcre-{{ version }}.tar.gz
@@ -20,13 +20,13 @@ source:
 
 requirements:
   build:
-    - bzip2
+    - libbzip2
     - gcc_npg >=7.3
     - zlib
     - xz
 
   run:
-    - bzip2
+    - libbzip2
     - libgcc_npg >=7.3
     - zlib
     - xz

--- a/recipes/staden_io_lib/1.14.6/meta.yaml
+++ b/recipes/staden_io_lib/1.14.6/meta.yaml
@@ -11,7 +11,7 @@ about:
   summary: DNA sequence assembly, editing and analysis tools.
 
 build:
-  number: 1
+  number: 2
 
 source:
   url: https://sourceforge.net/projects/staden/files/io_lib/{{ version }}/io_lib-{{ version }}.tar.gz/download
@@ -20,14 +20,14 @@ source:
 
 requirements:
   build:
-    - bzip2
+    - libbzip2
     - libcurl
     - gcc_npg >=7.3
     - xz
     - zlib
 
   run:
-    - bzip2
+    - libbzip2
     - libcurl
     - xz
     - zlib

--- a/recipes/staden_io_lib/1.14.6/meta.yaml
+++ b/recipes/staden_io_lib/1.14.6/meta.yaml
@@ -11,7 +11,7 @@ about:
   summary: DNA sequence assembly, editing and analysis tools.
 
 build:
-  number: 0
+  number: 1
 
 source:
   url: https://sourceforge.net/projects/staden/files/io_lib/{{ version }}/io_lib-{{ version }}.tar.gz/download
@@ -21,14 +21,14 @@ source:
 requirements:
   build:
     - bzip2
-    - curl
+    - libcurl
     - gcc_npg >=7.3
     - xz
     - zlib
 
   run:
     - bzip2
-    - curl
+    - libcurl
     - xz
     - zlib
 

--- a/recipes/staden_io_lib/1.14.9/meta.yaml
+++ b/recipes/staden_io_lib/1.14.9/meta.yaml
@@ -11,7 +11,7 @@ about:
   summary: DNA sequence assembly, editing and analysis tools.
 
 build:
-  number: 1
+  number: 2
 
 source:
   url: https://sourceforge.net/projects/staden/files/io_lib/{{ version }}/io_lib-{{ version }}.tar.gz/download
@@ -20,14 +20,14 @@ source:
 
 requirements:
   build:
-    - bzip2
+    - libbzip2
     - libcurl
     - gcc_npg >=7.3
     - xz
     - zlib
 
   run:
-    - bzip2
+    - libbzip2
     - libcurl
     - xz
     - zlib

--- a/recipes/staden_io_lib/1.14.9/meta.yaml
+++ b/recipes/staden_io_lib/1.14.9/meta.yaml
@@ -11,7 +11,7 @@ about:
   summary: DNA sequence assembly, editing and analysis tools.
 
 build:
-  number: 0
+  number: 1
 
 source:
   url: https://sourceforge.net/projects/staden/files/io_lib/{{ version }}/io_lib-{{ version }}.tar.gz/download
@@ -21,14 +21,14 @@ source:
 requirements:
   build:
     - bzip2
-    - curl
+    - libcurl
     - gcc_npg >=7.3
     - xz
     - zlib
 
   run:
     - bzip2
-    - curl
+    - libcurl
     - xz
     - zlib
 


### PR DESCRIPTION
Split bzip2 into executable and library/header packages. Updated packages that depend on the library package. (I branched this off https://github.com/keithj/npg_conda/tree/curl-deps in order to avoid conflicts where `build: number` is incremented)