### PR TITLE
Fix to build bambi 0.10.1 from the release tag

### DIFF
--- a/recipes/bambi/0.10.1/meta.yaml
+++ b/recipes/bambi/0.10.1/meta.yaml
@@ -14,7 +14,7 @@ build:
 
 source:
   git_url: https://github.com/wtsi-npg/bambi.git
-  git_rev: devel
+  git_rev: 0.10.1
 
 requirements:
   build:


### PR DESCRIPTION
 Build number intentionally left unchanged. This was never deployed.