### PR TITLE
Fixed pb_calibration build (multiple configuration errors mean that it

### DIFF
--- a/recipes/pb_calibration/10.28/build.sh
+++ b/recipes/pb_calibration/10.28/build.sh
@@ -5,7 +5,7 @@ set -e
 n=`expr $CPU_COUNT / 4 \| 1`
 
 pushd samtools
-make -j $n
+make -j $n DFLAGS="-D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -D_USE_KNETFILE" LIBCURSES=
 popd
 
 pushd pb_calibration

--- a/recipes/pb_calibration/10.28/meta.yaml
+++ b/recipes/pb_calibration/10.28/meta.yaml
@@ -26,13 +26,15 @@ source:
 
 requirements:
   build:
-    - curl
-    - gcc_npg <=5.0
-    - staden_io_lib <=10.14.6
+    - libcurl
+    - gcc_npg >=7.3
+    - libgd
+    - staden_io_lib <=1.14.6
     - zlib
 
   run:
-    - curl
+    - libcurl
+    - libgd
     - staden_io_lib
     - zlib
 


### PR DESCRIPTION
Fixed pb_calibration build (multiple configuration errors mean that it never has never been built)