### PR TITLE
htslib depends on openssl for our builds

### DIFF
--- a/recipes/htslib/1.5/meta.yaml
+++ b/recipes/htslib/1.5/meta.yaml
@@ -12,7 +12,7 @@ about:
   summary: C library for high-throughput sequencing data formats.
 
 build:
-  number: 4
+  number: 5
   string: plugins_{{ plugins_rev }}_{{ PKG_BUILDNUM }}
   
 source:
@@ -33,6 +33,7 @@ requirements:
     - gcc_npg >=7.3
     - irods-dev # for plugins
     - liblzma
+    - openssl
     - zlib
 
 outputs:
@@ -44,6 +45,7 @@ outputs:
         - libbzip2
         - libcurl
         - liblzma
+        - openssl
         - zlib
     files:
       - bin/bgzip
@@ -59,6 +61,7 @@ outputs:
         - libbzip2
         - libcurl
         - liblzma
+        - openssl
         - zlib
     files:
       - include/htslib

--- a/recipes/htslib/1.6/meta.yaml
+++ b/recipes/htslib/1.6/meta.yaml
@@ -12,7 +12,7 @@ about:
   summary: C library for high-throughput sequencing data formats.
 
 build:
-  number: 4
+  number: 5
   string: plugins_{{ plugins_rev }}_{{ PKG_BUILDNUM }}
 
 source:
@@ -33,6 +33,7 @@ requirements:
     - gcc_npg >=7.3
     - irods-dev # for plugins
     - liblzma
+    - openssl
     - zlib
 
 outputs:
@@ -44,6 +45,7 @@ outputs:
         - libbzip2
         - libcurl
         - liblzma
+        - openssl
         - zlib
     files:
       - bin/bgzip
@@ -59,6 +61,7 @@ outputs:
         - libbzip2
         - libcurl
         - liblzma
+        - openssl
         - zlib
     files:
       - include/htslib

--- a/recipes/htslib/1.7/meta.yaml
+++ b/recipes/htslib/1.7/meta.yaml
@@ -12,7 +12,7 @@ about:
   summary: C library for high-throughput sequencing data formats.
 
 build:
-  number: 4
+  number: 5
   string: plugins_{{ plugins_rev }}_{{ PKG_BUILDNUM }}
 
 source:
@@ -33,6 +33,7 @@ requirements:
     - gcc_npg >=7.3
     - irods-dev # for plugins
     - liblzma
+    - openssl
     - zlib
 
 outputs:
@@ -44,6 +45,7 @@ outputs:
         - libbzip2
         - libcurl
         - liblzma
+        - openssl
         - zlib
     files:
       - bin/bgzip
@@ -59,6 +61,7 @@ outputs:
         - libbzip2
         - libcurl
         - liblzma
+        - openssl
         - zlib
     files:
       - include/htslib

--- a/recipes/htslib/1.8/meta.yaml
+++ b/recipes/htslib/1.8/meta.yaml
@@ -12,7 +12,7 @@ about:
   summary: C library for high-throughput sequencing data formats.
 
 build:
-  number: 2
+  number: 3
   string: plugins_{{ plugins_rev }}_{{ PKG_BUILDNUM }}
 
 source:
@@ -33,6 +33,7 @@ requirements:
     - gcc_npg >=7.3
     - irods-dev >=4.1.12 # for plugins
     - liblzma
+    - openssl
     - zlib
 
 outputs:
@@ -44,6 +45,7 @@ outputs:
         - libbzip2
         - libcurl
         - liblzma
+        - openssl
         - zlib
     files:
       - bin/bgzip
@@ -59,6 +61,7 @@ outputs:
         - libbzip2
         - libcurl
         - liblzma
+        - openssl
         - zlib
     files:
       - include/htslib


### PR DESCRIPTION
This dependency is introduced by https://github.com/wtsi-npg/bambi/blob/devel/m4/ax_with_htslib.m4 linking `libcrypto.so`