### PR TITLE
iRODS build fixes

### DIFF
--- a/recipes/irods/4.1.12/build.sh
+++ b/recipes/irods/4.1.12/build.sh
@@ -2,6 +2,15 @@
 
 set -e
 
+
+function untar_data() {
+    if [ -e data.tar.gz ]; then
+        tar xz --strip-components=2 --directory="$PREFIX" --exclude='*.o' --exclude-backups < data.tar.gz
+    elif [ -e data.tar.xz ]; then
+        tar xJ --strip-components=2 --directory="$PREFIX" --exclude='*.o' --exclude-backups < data.tar.xz
+    fi
+}
+
 git submodule init && git submodule update
 
 export CCFLAGS="-I$PREFIX/include"
@@ -14,10 +23,10 @@ export TERM=dumb
 cd build
 
 ar vx irods-icommands-4.1.12-64bit.deb
-tar xJ --strip-components=2 --directory="$PREFIX" --exclude='*.o' --exclude-backups < data.tar.xz
+untar_data
 
 ar vx irods-dev-4.1.12-64bit.deb
-tar xJ --strip-components=2 --directory="$PREFIX" --exclude='*.o' --exclude-backups < data.tar.xz
+untar_data
 
 # Fix all the absolute symlinks pointing to /usr/include
 perl -le 'use strict; use File::Basename; foreach (@ARGV) { if (my $f = readlink $_) { if ($f =~ m{^/usr/}sm) { unlink $_; symlink(basename($f), $_) } } }' $PREFIX/include/irods/*.hpp

--- a/recipes/irods/4.1.12/meta.yaml
+++ b/recipes/irods/4.1.12/meta.yaml
@@ -25,7 +25,7 @@ source:
 
 requirements:
   build:
-    - gcc_npg ==4.6
+    - gcc_npg ==4.6.4
     - libbzip2
     - libcurl
     - libxml2


### PR DESCRIPTION
Use full gcc version number.

Allow for both tar.gz and tar.xz data archives in deb packages.