### PR TITLE
Set CPPFLAGS and LDFLAGS to use the correct zlib

### DIFF
--- a/recipes/minimap2/2.10/Makefile.patch
+++ b/recipes/minimap2/2.10/Makefile.patch
@@ -1,0 +1,15 @@
+--- Makefile	2018-03-27 16:47:59.000000000 +0100
++++ Makefile.1	2018-06-18 14:45:26.262092000 +0100
+@@ -29,10 +29,10 @@
+ extra:all $(PROG_EXTRA)
+ 
+ minimap2:main.o getopt.o libminimap2.a
+-		$(CC) $(CFLAGS) main.o getopt.o -o $@ -L. -lminimap2 $(LIBS)
++		$(CC) $(CFLAGS) main.o getopt.o -o $@ -L. $(LDFLAGS) -lminimap2 $(LIBS)
+ 
+ minimap2-lite:example.o libminimap2.a
+-		$(CC) $(CFLAGS) $< -o $@ -L. -lminimap2 $(LIBS)
++		$(CC) $(CFLAGS) $< -o $@ -L. $(LDFLAGS) -lminimap2 $(LIBS)
+ 
+ libminimap2.a:$(OBJS)
+ 		$(AR) -csru $@ $(OBJS)

--- a/recipes/minimap2/2.10/build.sh
+++ b/recipes/minimap2/2.10/build.sh
@@ -4,7 +4,7 @@ set -e
 
 n=`expr $CPU_COUNT / 4 \| 1`
 
-make -j $n
+make -j $n CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
 
 mkdir -p "$PREFIX/bin"
 cp minimap2 "$PREFIX/bin/"

--- a/recipes/minimap2/2.10/meta.yaml
+++ b/recipes/minimap2/2.10/meta.yaml
@@ -11,11 +11,14 @@ about:
   summary: "A versatile pairwise aligner for genomic and spliced nucleotide sequences."
 
 build:
-  number: 0
+  number: 1
 
 source:
   url: https://github.com/lh3/minimap2/releases/download/v{{ version }}/minimap2-{{ version }}.tar.bz2
   sha256: {{ sha256 }}
+
+  patches:
+    - Makefile.patch
 
 requirements:
   build:

--- a/recipes/minimap2/2.8/Makefile.patch
+++ b/recipes/minimap2/2.8/Makefile.patch
@@ -1,0 +1,15 @@
+--- Makefile	2018-06-18 14:12:28.482950000 +0100
++++ Makefile.1	2018-06-18 14:46:12.234408000 +0100
+@@ -29,10 +29,10 @@
+ extra:all $(PROG_EXTRA)
+ 
+ minimap2:main.o getopt.o libminimap2.a
+-		$(CC) $(CFLAGS) main.o getopt.o -o $@ -L. -lminimap2 $(LIBS)
++		$(CC) $(CFLAGS) main.o getopt.o -o $@ -L. $(LDFLAGS) -lminimap2 $(LIBS)
+ 
+ minimap2-lite:example.o libminimap2.a
+-		$(CC) $(CFLAGS) $< -o $@ -L. -lminimap2 $(LIBS)
++		$(CC) $(CFLAGS) $< -o $@ -L. $(LDFLAGS) -lminimap2 $(LIBS)
+ 
+ libminimap2.a:$(OBJS)
+ 		$(AR) -csru $@ $(OBJS)

--- a/recipes/minimap2/2.8/build.sh
+++ b/recipes/minimap2/2.8/build.sh
@@ -4,7 +4,7 @@ set -e
 
 n=`expr $CPU_COUNT / 4 \| 1`
 
-make -j $n
+make -j $n CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
 
 mkdir -p "$PREFIX/bin"
 cp minimap2 "$PREFIX/bin/"

--- a/recipes/minimap2/2.8/meta.yaml
+++ b/recipes/minimap2/2.8/meta.yaml
@@ -11,11 +11,14 @@ about:
   summary: "A versatile pairwise aligner for genomic and spliced nucleotide sequences."
 
 build:
-  number: 0
+  number: 1
 
 source:
   url: https://github.com/lh3/minimap2/releases/download/v{{ version }}/minimap2-{{ version }}.tar.bz2
   sha256: {{ sha256 }}
+
+  patches:
+    - Makefile.patch
 
 requirements:
   build:


### PR DESCRIPTION
Set CPPFLAGS and LDFLAGS to use the correct zlib, patch to honour LDFLAGS.