### PR TITLE
Set CPPFLAGS and LDFLAGS to use the correct zlib.

### DIFF
--- a/recipes/bwa/0.7.17/Makefile.patch
+++ b/recipes/bwa/0.7.17/Makefile.patch
@@ -1,0 +1,21 @@
+--- Makefile	2018-06-19 15:36:55.684554000 +0100
++++ Makefile.1	2018-06-19 15:36:46.075489000 +0100
+@@ -22,15 +22,15 @@
+ .SUFFIXES:.c .o .cc
+ 
+ .c.o:
+-		$(CC) -c $(CFLAGS) $(DFLAGS) $(INCLUDES) $< -o $@
++		$(CC) -c $(CFLAGS) $(DFLAGS) $(INCLUDES) $(CPPFLAGS) $< -o $@
+ 
+ all:$(PROG)
+ 
+ bwa:libbwa.a $(AOBJS) main.o
+-		$(CC) $(CFLAGS) $(DFLAGS) $(AOBJS) main.o -o $@ -L. -lbwa $(LIBS)
++		$(CC) $(CFLAGS) $(DFLAGS) $(AOBJS) main.o -o $@ -L. $(LDFLAGS) -lbwa $(LIBS)
+ 
+ bwamem-lite:libbwa.a example.o
+-		$(CC) $(CFLAGS) $(DFLAGS) example.o -o $@ -L. -lbwa $(LIBS)
++		$(CC) $(CFLAGS) $(DFLAGS) example.o -o $@ -L. $(LDFLAGS) -lbwa $(LIBS)
+ 
+ libbwa.a:$(LOBJS)
+ 		$(AR) -csru $@ $(LOBJS)

--- a/recipes/bwa/0.7.17/build.sh
+++ b/recipes/bwa/0.7.17/build.sh
@@ -4,7 +4,7 @@ set -e
 
 n=`expr $CPU_COUNT / 4 \| 1`
 
-make -j $n
+make -j $n CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
 
 mkdir -p "$PREFIX/bin"
 cp bwa "$PREFIX/bin/"

--- a/recipes/bwa/0.7.17/meta.yaml
+++ b/recipes/bwa/0.7.17/meta.yaml
@@ -10,11 +10,14 @@ about:
   summary: Burrows-Wheeler Aligner for short-read alignment.
 
 build:
-  number: 0
+  number: 1
 
 source:
   - git_url: https://github.com/lh3/bwa.git
     git_rev: v{{ version }}
+
+    patches:
+      - Makefile.patch
 
 requirements:
   build:


### PR DESCRIPTION
This should be merged before tagging `1.0.0`. I forgot to merge it earlier - it was actually used to build the packages.