### PR TITLE
Added pre-1.9 samtools/htslib from respective develop branches.

### DIFF
--- a/recipes/bambi/0.11.1/meta.yaml
+++ b/recipes/bambi/0.11.1/meta.yaml
@@ -10,7 +10,7 @@ about:
   summary: "A set of programs to manipulate SAM/BAM/CRAM files, using HTSLIB."
 
 build:
-  number: 0
+  number: 1
 
 source:
   git_url: https://github.com/wtsi-npg/bambi.git

--- a/recipes/htslib/1.8+48-g6cd9f24/README.md
+++ b/recipes/htslib/1.8+48-g6cd9f24/README.md
@@ -1,0 +1,3 @@
+This post release build was created from the develop branch of htslib
+to support a version of samtools having recent additions to samtools
+stats.

--- a/recipes/htslib/1.8+48-g6cd9f24/build.sh
+++ b/recipes/htslib/1.8+48-g6cd9f24/build.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -e
+
+n=`expr $CPU_COUNT / 4 \| 1`
+
+pushd htslib
+autoreconf
+./configure --prefix="$PREFIX" \
+            --enable-libcurl \
+            --enable-plugins \
+            CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
+make -j $n
+make install prefix="$PREFIX"
+popd
+
+pushd plugins
+make install prefix="$PREFIX" IRODS_HOME="$PREFIX" \
+     CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
+popd

--- a/recipes/htslib/1.8+48-g6cd9f24/meta.yaml
+++ b/recipes/htslib/1.8+48-g6cd9f24/meta.yaml
@@ -1,0 +1,80 @@
+{% set version = "1.8+48_g6cd9f24" %}
+{% set plugins_rev = "201712" %}
+{% set htslib_rev = "6cd9f2477d729896d78c3ee6e6eb5fd89c50d372" %}
+
+package:
+  name: "htslib"
+  version: "{{ version }}"
+
+about:
+  home: https://github.com/samtools/htslib
+  license: MIT
+  summary: C library for high-throughput sequencing data formats.
+
+build:
+  number: 0
+  string: plugins_{{ plugins_rev }}_{{ PKG_BUILDNUM }}
+
+source:
+  - git_url: https://github.com/samtools/htslib.git
+    git_rev: {{ htslib_rev }}
+    folder: htslib
+  - git_url: https://github.com/samtools/htslib-plugins.git
+    git_rev: {{ plugins_rev }}
+    folder: plugins
+
+features:
+  - irods
+
+requirements:
+  build:
+    - libbzip2
+    - libcurl
+    - gcc_npg >=7.3
+    - irods-dev >=4.1.12 # for plugins
+    - liblzma
+    - openssl
+    - zlib
+
+outputs:
+  - name: htsbin
+    version: {{ version }}
+    requirements:
+      run:
+        - htslib =={{ version }}
+        - libbzip2
+        - libcurl
+        - liblzma
+        - openssl
+        - zlib
+    files:
+      - bin/bgzip
+      - bin/htsfile
+      - bin/tabix
+      - share/man/man1/htsfile.1
+      - share/man/man1/tabix.1
+
+  - name: htslib
+    version: {{ version }}
+    requirements:
+      run:
+        - libbzip2
+        - libcurl
+        - liblzma
+        - openssl
+        - zlib
+    files:
+      - include/htslib
+      - libexec/htslib
+      - lib/libhts*
+      - share/man/man5/faidx.5
+      - share/man/man5/sam.5
+      - share/man/man5/vcf.5
+
+    test:
+      commands:
+        - test -f ${PREFIX}/include/htslib/sam.h
+        - test -f ${PREFIX}/lib/libhts.a
+        - test -h ${PREFIX}/lib/libhts.so
+        - test -f ${PREFIX}/libexec/htslib/hfile_irods.so
+        - test -f ${PREFIX}/libexec/htslib/hfile_libcurl.so

--- a/recipes/samtools/1.8+59-g4da22a9/README.md
+++ b/recipes/samtools/1.8+59-g4da22a9/README.md
@@ -1,0 +1,2 @@
+This post release build was created from the develop branch of
+samtools to include recent additions to samtools stats.

--- a/recipes/samtools/1.8+59-g4da22a9/build.sh
+++ b/recipes/samtools/1.8+59-g4da22a9/build.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+n=`expr $CPU_COUNT / 4 \| 1`
+
+autoreconf
+./configure --prefix="$PREFIX" \
+            --with-htslib=system \
+            --without-curses \
+            CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
+
+make -j $n
+make install prefix="$PREFIX"

--- a/recipes/samtools/1.8+59-g4da22a9/meta.yaml
+++ b/recipes/samtools/1.8+59-g4da22a9/meta.yaml
@@ -1,0 +1,30 @@
+{% set version = "1.8+59_g4da22a9" %}
+{% set htslib_version = "1.8+48-g6cd9f24" %}
+
+package:
+  name: samtools
+  version: "{{ version }}"
+
+about:
+  home: https://github.com/samtools/samtools
+  license: MIT
+  summary: C library for high-throughput sequencing data formats.
+
+build:
+  number: 0
+
+source:
+  git_url: https://github.com/samtools/samtools.git
+  git_rev: 4da22a93ddee8d52953cd1b24af29e1d8904eb7e
+
+requirements:
+  build:
+    - gcc_npg >=7.3
+    - htslib =={{ htslib_version }}
+
+  run:
+    - htslib =={{ htslib_version }}
+
+test:
+  commands:
+    - echo '@HD VN:1.0 SO:coordinate' | samtools view


### PR DESCRIPTION
Also bumped the build number of `bambi` which statically links htslib.