### PR TITLE
Move aclocal.m4 to avoid dirty builds

### DIFF
--- a/recipes/htslib/1.9+9-g6ec3b94/build.sh
+++ b/recipes/htslib/1.9+9-g6ec3b94/build.sh
@@ -5,7 +5,11 @@ set -e
 n=`expr $CPU_COUNT / 4 \| 1`
 
 pushd htslib
+
+cp aclocal.m4 aclocal.m4.tmp
 autoreconf
+cp aclocal.m4.tmp aclocal.m4
+
 ./configure --prefix="$PREFIX" \
             --enable-libcurl \
             --enable-plugins \

--- a/recipes/htslib/1.9+9-g6ec3b94/meta.yaml
+++ b/recipes/htslib/1.9+9-g6ec3b94/meta.yaml
@@ -12,7 +12,7 @@ about:
   summary: C library for high-throughput sequencing data formats.
 
 build:
-  number: 0
+  number: 1
   string: plugins_{{ plugins_rev }}_{{ PKG_BUILDNUM }}
 
 source:


### PR DESCRIPTION
Since the last release, htslib has aclocal.m4 checked in. When autoreconf is run
(or autoconf) during builds from a git clone, aclocal.m4 gets overwritten, making the
build report itself as dirty (using git describe). This is a workaround which
temporarily moves the file out of the way.