### PR TITLE
The domain hosting bzip expired

### DIFF
--- a/recipes/bzip2/1.0.6/meta.yaml
+++ b/recipes/bzip2/1.0.6/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.0.6" %}
-{% set sha256 = "a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd" %}
+{% set sha256 = "d70a9ccd8bdf47e302d96c69fecd54925f45d9c7b966bb4ef5f56b770960afa7" %}
 
 package:
   name: bzip2
@@ -11,10 +11,10 @@ about:
   summary: Data compressor.
 
 build:
-  number: 1
+  number: 2
   
 source:
-  url: http://bzip.org/{{ version }}/bzip2-{{ version }}.tar.gz
+  url: http://http.debian.net/debian/pool/main/b/bzip2/bzip2_{{ version }}.orig.tar.bz2
   fn: bzip2-{{ version }}.tar.gz
   sha256: {{ sha256 }}
   patches:


### PR DESCRIPTION
The domain hosting bzip expired so changed the source code home to the Debian copy.