### PR TITLE
Bambi release 0.11.2

### DIFF
--- a/recipes/bambi/0.11.2/build.sh
+++ b/recipes/bambi/0.11.2/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+autoreconf -fi
+
+n=`expr $CPU_COUNT / 4 \| 1`
+
+./configure --prefix="$PREFIX" --with-htslib="$PREFIX" CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
+
+make -j $n CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
+make install prefix="$PREFIX"

--- a/recipes/bambi/0.11.2/meta.yaml
+++ b/recipes/bambi/0.11.2/meta.yaml
@@ -1,0 +1,35 @@
+{% set version = "0.11.2" %}
+{% set htslib_version = "1.9+66_gbcf9bff" %}
+
+
+package:
+  name: bambi
+  version: "{{ version }}"
+
+about:
+  home: https://github.com/wtsi-npg/bambi
+  license: AGPL
+  summary: "A set of programs to manipulate SAM/BAM/CRAM files, using HTSLIB."
+
+build:
+  number: 0
+
+source:
+  git_url: https://github.com/wtsi-npg/bambi.git
+  git_rev: 0.11.2
+
+requirements:
+  build:
+    - gcc_npg >=7.3
+    - htslib =={{ htslib_version }}
+    - libgd
+    - libxml2
+
+  run:
+    - htslib =={{ htslib_version }}
+    - libgd
+    - libxml2
+
+test:
+  commands:
+    - bambi --version


### PR DESCRIPTION
Bambi release 0.11.2 (fixes integer overflow in Bambi, https://github.com/wtsi-npg/bambi/pull/133)