### PR TITLE
Bambi 0.12.2

### DIFF
--- a/recipes/bambi/0.12.2/build.sh
+++ b/recipes/bambi/0.12.2/build.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -ex
+
+autoreconf -fi
+
+n="$CPU_COUNT"
+
+CPPFLAGS="-I$PREFIX/include" LDFLAGS="-Wl,-rpath,$PREFIX/lib -L$PREFIX/lib" \
+        ./configure --prefix="$PREFIX" --with-htslib="$PREFIX"
+
+make -j $n CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
+make install prefix="$PREFIX"

--- a/recipes/bambi/0.12.2/meta.yaml
+++ b/recipes/bambi/0.12.2/meta.yaml
@@ -1,0 +1,41 @@
+{% set version = "0.12.2" %}
+{% set htslib_version = "1.9+353_gefa7aa6" %}
+
+package:
+  name: bambi
+  version: "{{ version }}"
+
+about:
+  home: https://github.com/wtsi-npg/bambi
+  license: AGPL
+  summary: "A set of programs to manipulate SAM/BAM/CRAM files, using HTSLIB."
+
+build:
+  number: 0
+
+source:
+  git_url: https://github.com/wtsi-npg/bambi.git
+  git_rev: {{ version }}
+
+requirements:
+  build:
+    - {{ compiler("c") }}
+    - autoconf
+    - automake
+    - make
+    - perl
+    - pkg-config
+  host:
+    - libgd-dev
+    - libhts-dev =={{ htslib_version }}
+    - libxml2-dev
+    - libz-dev
+  run:
+    - libgd
+    - libhts =={{ htslib_version }}
+    - libxml2
+    - libz
+
+test:
+  commands:
+    - bambi --version

--- a/recipes/bambi/develop/build.sh
+++ b/recipes/bambi/develop/build.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -ex
+
+autoreconf -fi
+
+n="$CPU_COUNT"
+
+CPPFLAGS="-I$PREFIX/include" LDFLAGS="-Wl,-rpath,$PREFIX/lib -L$PREFIX/lib" \
+        ./configure --prefix="$PREFIX" --with-htslib="$PREFIX"
+
+make -j $n CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
+make install prefix="$PREFIX"

--- a/recipes/bambi/develop/meta.yaml
+++ b/recipes/bambi/develop/meta.yaml
@@ -1,0 +1,41 @@
+{% set version = "0.12.0+8_g35ecfdf" %}
+{% set htslib_version = "1.9+353_gefa7aa6" %}
+
+package:
+  name: bambi
+  version: "{{ version }}"
+
+about:
+  home: https://github.com/wtsi-npg/bambi
+  license: AGPL
+  summary: "A set of programs to manipulate SAM/BAM/CRAM files, using HTSLIB."
+
+build:
+  number: 0
+
+source:
+  git_url: https://github.com/wtsi-npg/bambi.git
+  git_rev: 35ecfdf89cbff066758eed4ce87055a243184d9a
+
+requirements:
+  build:
+    - {{ compiler("c") }}
+    - autoconf
+    - automake
+    - make
+    - perl
+    - pkg-config
+  host:
+    - libgd-dev
+    - libhts-dev =={{ htslib_version }}
+    - libxml2-dev
+    - libz-dev
+  run:
+    - libgd
+    - libhts =={{ htslib_version }}
+    - libxml2
+    - libz
+
+test:
+  commands:
+    - bambi --version

--- a/recipes/bambi/develop/meta.yaml
+++ b/recipes/bambi/develop/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.12.0+8_g35ecfdf" %}
+{% set version = "0.12.0+8_g35ecfdf" %} # reset build to zero on changing
 {% set htslib_version = "1.9+353_gefa7aa6" %}
 
 package:

--- a/recipes/htslib/1.9+353_gefa7aa6/build.sh
+++ b/recipes/htslib/1.9+353_gefa7aa6/build.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -ex
+
+n="$CPU_COUNT"
+
+pushd htslib
+
+cp aclocal.m4 aclocal.m4.tmp
+autoreconf
+cp aclocal.m4.tmp aclocal.m4
+
+./configure \
+    --prefix="$PREFIX" \
+    --with-libdeflate \
+    --enable-libcurl \
+    --enable-s3 \
+    --enable-gcs \
+    --enable-plugins \
+    CC="$GCC" CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
+
+make -j $n AR="$AR"
+make install prefix="$PREFIX"
+popd
+

--- a/recipes/htslib/1.9+353_gefa7aa6/meta.yaml
+++ b/recipes/htslib/1.9+353_gefa7aa6/meta.yaml
@@ -1,0 +1,120 @@
+{% set version = "1.9+353_gefa7aa6" %}
+{% set htslib_rev = "efa7aa632f5f3b73362c3f94be79ca5d49d2bfe4" %}
+
+package:
+  name: htslib-pkg
+  version: "{{ version }}"
+
+about:
+  home: https://github.com/samtools/htslib
+  license: MIT
+  summary: C library for high-throughput sequencing data formats.
+
+build:
+  number: 4
+
+source:
+  - git_url: https://github.com/samtools/htslib.git
+    git_rev: {{ htslib_rev }}
+    folder: htslib
+
+requirements:
+  build:
+    - {{ compiler("c") }}
+    - autoconf
+    - automake
+    - make
+    - perl
+  host:
+    - libbz2-dev
+    - libcurl-dev
+    - libdeflate-dev
+    - liblzma-dev
+    - libssl-dev
+    - libz-dev
+  run:
+    - libbz2
+    - libcurl
+    - libdeflate
+    - liblzma
+    - libssl
+    - libz
+
+outputs:
+  - name: htslib
+    version: {{ version }}
+    requirements:
+      build:
+        - {{ compiler("c") }}
+        - autoconf
+        - automake
+        - make
+        - perl
+      host:
+        - libbz2-dev
+        - libcurl-dev
+        - libdeflate-dev
+        - liblzma-dev
+        - libssl-dev
+        - libz-dev
+      run:
+        - {{ pin_subpackage("libhts", exact=True) }}
+        - libbz2
+        - libcurl
+        - libdeflate
+        - liblzma
+        - libssl
+        - libz
+    files:
+      - bin/bgzip
+      - bin/htsfile
+      - bin/tabix
+      - share/man/man1/htsfile.1
+      - share/man/man1/tabix.1
+
+  - name: libhts
+    version: {{ version }}
+    requirements:
+      build:
+        - {{ compiler("c") }}
+        - autoconf
+        - automake
+        - make
+        - perl
+      host:
+        - libbz2-dev
+        - libcurl-dev
+        - libdeflate-dev
+        - liblzma-dev
+        - libssl-dev
+        - libz-dev
+      run:
+        - libbz2
+        - libcurl
+        - libdeflate
+        - liblzma
+        - libssl
+        - libz
+    files:
+      - libexec/htslib
+      - lib/libhts.so*
+    test:
+      commands:
+        - test -h ${PREFIX}/lib/libhts.so
+        - test -f ${PREFIX}/libexec/htslib/hfile_libcurl.so
+
+  - name: libhts-dev
+    version: {{ version }}
+    requirements:
+      run:
+        - {{ pin_subpackage("libhts", exact=True) }}
+    files:
+      - include/htslib
+      - lib/libhts.a
+      - share/man/man5/faidx.5
+      - share/man/man5/sam.5
+      - share/man/man5/vcf.5
+    test:
+      commands:
+        - test -f ${PREFIX}/lib/libhts.a
+        - test -f ${PREFIX}/include/htslib/sam.h

--- a/recipes/htslib/develop/meta.yaml
+++ b/recipes/htslib/develop/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.9+353_gefa7aa6" %}
+{% set version = "1.9+353_gefa7aa6" %} # reset build to zero on changing
 {% set htslib_rev = "efa7aa632f5f3b73362c3f94be79ca5d49d2bfe4" %}
 
 package:

--- a/recipes/samtools/develop/meta.yaml
+++ b/recipes/samtools/develop/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.9+168_gb1e2c78" %}
+{% set version = "1.9+168_gb1e2c78" %} # reset build to zero on changing
 {% set htslib_version = "1.9+353_gefa7aa6" %}
 
 package:


### PR DESCRIPTION
Required for longer read names for NovaSeq
Bring in its htslib dependency with explicit recipe.
Annotate develop recipes with build number reset advice.