### PR TITLE
Create conda recipe for BWA-MEM2

### DIFF
--- a/recipes/bwa-mem2/v2.0pre1-25-g1038fe3/Makefile.patch
+++ b/recipes/bwa-mem2/v2.0pre1-25-g1038fe3/Makefile.patch
@@ -1,0 +1,31 @@
+diff --git a/Makefile b/Makefile
+index b86eda9..1aec8d6 100644
+--- a/Makefile
++++ b/Makefile
+@@ -33,7 +33,7 @@ EXE=		bwa-mem2
+ ARCH_FLAGS=	-msse4.1
+ SWA_FLAGS=	-DDEB=0 -DRDT=0 -DMAXI=0 -DNEW=1 -DSORT_PAIRS=0
+ MEM_FLAGS=	-DPAIRED_END=1 -DMAINY=0 -DSAIS=1
+-CPPFLAGS=	-DENABLE_PREFETCH $(MEM_FLAGS) $(SWA_FLAGS) 
++CPPFLAGS+=	-DENABLE_PREFETCH $(MEM_FLAGS) $(SWA_FLAGS) 
+ LIBS=		-lpthread -lm -lz ##-lnuma
+ OBJS=		src/fastmap.o src/bwtindex.o src/main.o src/utils.o src/kthread.o \
+ 			src/kstring.o src/ksw.o src/bntseq.o src/bwamem.o src/profiling.o src/bandedSWA.o \
+@@ -62,7 +62,7 @@ else ifeq ($(arch),native)
+ 	ARCH_FLAGS=-march=native
+ endif
+ 
+-CXXFLAGS=	-g -O3 -fpermissive $(ARCH_FLAGS) #-Wall ##-xSSE2
++CXXFLAGS+=	-g -O3 -fpermissive $(ARCH_FLAGS) #-Wall ##-xSSE2
+ 
+ .PHONY:all clean depend multi
+ .SUFFIXES:.cpp .o
+@@ -79,7 +79,7 @@ multi:
+ 	$(CXX) -Wall -O3 src/runsimd.cpp -o bwa-mem2
+ 
+ $(EXE):$(OBJS)
+-	$(CXX) $(CXXFLAGS) $(OBJS) -o $@ $(LIBS)
++	$(CXX) $(LDFLAGS) $(CXXFLAGS) $(OBJS) -o $@ $(LIBS)
+ 
+ clean:
+ 	rm -fr src/*.o $(EXE) bwa-mem2.sse41 bwa-mem2.avx2 bwa-mem2.avx512bw

--- a/recipes/bwa-mem2/v2.0pre1-25-g1038fe3/build.sh
+++ b/recipes/bwa-mem2/v2.0pre1-25-g1038fe3/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -ex
+PVERSION=$(git describe --tags --always)
+CPPFLAGS="-I$PREFIX/include -DPACKAGE_VERSION='"'"'$PVERSION'"'"'" LDFLAGS="-L$PREFIX/lib" make -j $CPU_COUNT multi
+
+mkdir -p "$PREFIX/bin"
+cp bwa-mem2 "$PREFIX/bin/"
+cp bwa-mem2.sse41 "$PREFIX/bin/"
+cp bwa-mem2.avx2 "$PREFIX/bin/"
+cp bwa-mem2.avx512bw "$PREFIX/bin/"

--- a/recipes/bwa-mem2/v2.0pre1-25-g1038fe3/meta.yaml
+++ b/recipes/bwa-mem2/v2.0pre1-25-g1038fe3/meta.yaml
@@ -1,0 +1,34 @@
+{% set version = "v2.0pre1_25_g1038fe3" %}
+{% set bwa_mem2_rev = "1038fe3b701cb6cd6e8c10a5ffbfdf5512167da2" %}
+
+package:
+  name: bwa-mem2
+  version: "{{ version }}"
+
+about:
+  home: https://github.com/bwa-mem2/bwa-mem2
+  license: MIT
+  summary: Burrows-Wheeler Aligner for short-read alignment.
+
+build:
+  number: 1
+
+source:
+  - git_url: https://github.com/bwa-mem2/bwa-mem2.git
+    git_rev: "{{bwa_mem2_rev }}"
+
+    patches:
+      - Makefile.patch
+
+requirements:
+  build:
+    - {{ compiler("cxx") }}
+    - make
+  host:
+    - libz-dev
+  run:
+    - libz
+
+test:
+  commands:
+    - test -x ${PREFIX}/bin/bwa-mem2


### PR DESCRIPTION
Patch to:
-Add more automated, version string propagation
-Include LDFLAGS to the right place in linker string.

Co-authored-by: David K. Jackson <david.jackson@sanger.ac.uk>