### PR TITLE
samtools/htslib/bcftools 1.10

### DIFF
--- a/recipes/bcftools/1.10/build.sh
+++ b/recipes/bcftools/1.10/build.sh
@@ -4,8 +4,8 @@ set -ex
 
 n="$CPU_COUNT"
 
-CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib" \
-        ./configure --prefix="$PREFIX" --with-htslib="$PREFIX" 
+./configure --prefix="$PREFIX" --with-htslib="$PREFIX" \
+  CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
 
-make -j $n CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
+make -j $n 
 make install prefix="$PREFIX"

--- a/recipes/bcftools/1.10/build.sh
+++ b/recipes/bcftools/1.10/build.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -ex
+
+n="$CPU_COUNT"
+
+CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib" \
+        ./configure --prefix="$PREFIX" --with-htslib="$PREFIX" 
+
+make -j $n CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
+make install prefix="$PREFIX"

--- a/recipes/bcftools/1.10/meta.yaml
+++ b/recipes/bcftools/1.10/meta.yaml
@@ -1,0 +1,36 @@
+{% set version = "1.10.0" %} # reset build to zero on changing
+{% set upstream_version = "1.10" %}
+{% set htslib_version = "1.10.0" %}
+{% set sha256 = "2a37721b944772633f334cc0897c43430d56cf59d7363b72d5cd2cfc9ae3af83" %}
+
+package:
+  name: bcftools
+  version: "{{ version }}"
+
+about:
+  home: https://github.com/samtools/bcftools
+  license: MIT
+  summary: VCF commands and BCF calling.
+
+build:
+  number: 0
+
+source:
+  url: https://github.com/samtools/bcftools/releases/download/{{ upstream_version }}/bcftools-{{ upstream_version }}.tar.bz2
+  fn: bcftools-{{ upstream_version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+requirements:
+  build:
+    - {{ compiler("c") }}
+    - make
+  host:
+    - libhts-dev =={{ htslib_version }}
+    - libz-dev
+  run:
+    - libhts =={{ htslib_version }}
+    - libz
+
+test:
+  commands:
+    - bcftools --help

--- a/recipes/htslib/1.10/build.sh
+++ b/recipes/htslib/1.10/build.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -ex
+
+n="$CPU_COUNT"
+
+pushd htslib
+
+cp aclocal.m4 aclocal.m4.tmp
+autoreconf
+cp aclocal.m4.tmp aclocal.m4
+
+./configure \
+    --prefix="$PREFIX" \
+    --with-libdeflate \
+    --enable-libcurl \
+    --enable-s3 \
+    --enable-gcs \
+    --enable-plugins \
+    CC="$GCC" CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
+
+make -j $n AR="$AR"
+make install prefix="$PREFIX"
+popd
+

--- a/recipes/htslib/1.10/meta.yaml
+++ b/recipes/htslib/1.10/meta.yaml
@@ -1,0 +1,120 @@
+{% set version = "1.10.0" %} # reset build to zero on changing
+{% set htslib_rev = "7c16b5665daf4b2af82574d24f1649f3c385fe2c" %}
+
+package:
+  name: htslib-pkg
+  version: "{{ version }}"
+
+about:
+  home: https://github.com/samtools/htslib
+  license: MIT
+  summary: C library for high-throughput sequencing data formats.
+
+build:
+  number: 0
+
+source:
+  - git_url: https://github.com/samtools/htslib.git
+    git_rev: {{ htslib_rev }}
+    folder: htslib
+
+requirements:
+  build:
+    - {{ compiler("c") }}
+    - autoconf
+    - automake
+    - make
+    - perl
+  host:
+    - libbz2-dev
+    - libcurl-dev
+    - libdeflate-dev
+    - liblzma-dev
+    - libssl-dev
+    - libz-dev
+  run:
+    - libbz2
+    - libcurl
+    - libdeflate
+    - liblzma
+    - libssl
+    - libz
+
+outputs:
+  - name: htslib
+    version: {{ version }}
+    requirements:
+      build:
+        - {{ compiler("c") }}
+        - autoconf
+        - automake
+        - make
+        - perl
+      host:
+        - libbz2-dev
+        - libcurl-dev
+        - libdeflate-dev
+        - liblzma-dev
+        - libssl-dev
+        - libz-dev
+      run:
+        - {{ pin_subpackage("libhts", exact=True) }}
+        - libbz2
+        - libcurl
+        - libdeflate
+        - liblzma
+        - libssl
+        - libz
+    files:
+      - bin/bgzip
+      - bin/htsfile
+      - bin/tabix
+      - share/man/man1/htsfile.1
+      - share/man/man1/tabix.1
+
+  - name: libhts
+    version: {{ version }}
+    requirements:
+      build:
+        - {{ compiler("c") }}
+        - autoconf
+        - automake
+        - make
+        - perl
+      host:
+        - libbz2-dev
+        - libcurl-dev
+        - libdeflate-dev
+        - liblzma-dev
+        - libssl-dev
+        - libz-dev
+      run:
+        - libbz2
+        - libcurl
+        - libdeflate
+        - liblzma
+        - libssl
+        - libz
+    files:
+      - libexec/htslib
+      - lib/libhts.so*
+    test:
+      commands:
+        - test -h ${PREFIX}/lib/libhts.so
+        - test -f ${PREFIX}/libexec/htslib/hfile_libcurl.so
+
+  - name: libhts-dev
+    version: {{ version }}
+    requirements:
+      run:
+        - {{ pin_subpackage("libhts", exact=True) }}
+    files:
+      - include/htslib
+      - lib/libhts.a
+      - share/man/man5/faidx.5
+      - share/man/man5/sam.5
+      - share/man/man5/vcf.5
+    test:
+      commands:
+        - test -f ${PREFIX}/lib/libhts.a
+        - test -f ${PREFIX}/include/htslib/sam.h

--- a/recipes/samtools/1.10/build.sh
+++ b/recipes/samtools/1.10/build.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -ex
+
+n="$CPU_COUNT"
+
+autoreconf
+
+./configure --prefix="$PREFIX" \
+            --with-htslib=system \
+            --without-curses \
+            CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
+        
+make -j "$n" AR="$AR"
+make install prefix="$PREFIX"
+
+mkdir p "$PREFIX/include/samtools"
+cp "$SRC_DIR/"*.h "$PREFIX/include/samtools/"
+cp "$SRC_DIR/libbam.a" "$PREFIX/lib"

--- a/recipes/samtools/1.10/meta.yaml
+++ b/recipes/samtools/1.10/meta.yaml
@@ -1,0 +1,75 @@
+{% set version = "1.10.0" %} # reset build to zero on changing
+{% set htslib_version = "1.10.0" %}
+
+package:
+  name: samtools-pkg
+  version: "{{ version }}"
+
+about:
+  home: https://github.com/samtools/samtools
+  license: MIT
+  summary: C library for high-throughput sequencing data formats.
+
+build:
+  number: 0
+
+source:
+  git_url: https://github.com/samtools/samtools.git
+  git_rev: 76877ea4e41cd9d9a7f045307485535c7da7422b
+
+requirements:
+  build:
+    - {{ compiler("c") }}
+    - autoconf
+    - automake
+    - make
+    - perl
+  host:
+    - libhts-dev =={{ htslib_version }}
+    - libz-dev
+  run:
+    - libhts =={{ htslib_version }}
+    - libz
+
+outputs:
+  - name: samtools
+    version: {{ version }}
+    requirements:
+      build:
+        - {{ compiler("c") }}
+        - autoconf
+        - automake
+        - make
+        - perl
+      host:
+        - libhts-dev =={{ htslib_version }}
+        - libz-dev
+      run:
+        - libhts =={{ htslib_version }}
+        - libz
+    files:
+      - bin/ace2sam
+      - bin/maq2sam-*
+      - bin/md5*
+      - bin/plot-bamstats
+      - bin/samtools
+      - bin/wgsim
+      - bin/*.pl
+      - bin/*.py
+    test:
+      commands:
+        - echo -e '@HD\tVN:1.0\tSO:unsorted' | samtools view
+
+  - name: samtools-dev
+    version: {{ version }}
+    requirements:
+      run:
+        - libhts =={{ htslib_version }}
+        - libz
+    files:
+      - include/samtools/*.h
+      - lib/libbam.a
+    test:
+      commands:
+        - test -f ${PREFIX}/include/samtools/sam.h
+        - test -f ${PREFIX}/lib/libbam.a


### PR DESCRIPTION
Note that the conda version for these tools is `1.10.0` rather than `1.10` as the upstream versioning - this is to avoid packages with version `1.1` being created (i.e. version string being treated as a decimal)