### PR TITLE
First possibly working version of IRODS 4.2.7

### DIFF
--- a/recipes/avrocpp/1.8.2/bld.bat
+++ b/recipes/avrocpp/1.8.2/bld.bat
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+mkdir build
+cd build
+
+cmake -G "NMake Makefiles" ^
+    -DCMAKE_INSTALL_PREFIX:PATH="%LIBRARY_PREFIX%" ^
+    -DCMAKE_PREFIX_PATH:PATH="%LIBRARY_PREFIX%" ^
+    -DBOOST_ROOT:PATH="%PREFIX%" ^
+    -DSNAPPY_ROOT_DIR:PATH="%PREFIX%" ^
+    -DCMAKE_BUILD_TYPE:STRING=Release ^
+    -DBUILD_SHARED_LIBS=ON ^
+    ..
+if errorlevel 1 exit 1
+
+nmake
+if errorlevel 1 exit 1
+
+nmake install
+if errorlevel 1 exit 1

--- a/recipes/avrocpp/1.8.2/build.sh
+++ b/recipes/avrocpp/1.8.2/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -exuo pipefail
+
+mkdir build
+cd build
+echo prefix=${PREFIX}
+export CXXFLAGS="-I$BUILD_PREFIX/include"
+export LDFLAGS="-L$BUILD_PREFIX/lib -lrt"
+echo $CXXFLAGS
+
+cmake .. \
+  -DCMAKE_INSTALL_PREFIX=$PREFIX \
+  -DBOOST_ROOT=$PREFIX \
+  -DSNAPPY_ROOT_DIR=$PREFIX \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DCMAKE_AR=$AR 
+
+make # VERBOSE=1
+#make test
+make install

--- a/recipes/avrocpp/1.8.2/meta.yaml
+++ b/recipes/avrocpp/1.8.2/meta.yaml
@@ -1,0 +1,55 @@
+{% set version = "1.8.2" %}
+{% set hash = "c17d84613187dda3611c9c95d6f3388036a330ba" %}
+{% set name = "avrocpp" %}
+
+package:
+    name: {{ name }}
+    version: {{ version }}
+
+source:
+    fn: avro-cpp-{{ version }}.tar.gz
+    url: https://archive.apache.org/dist/avro/avro-{{ version }}/cpp/avro-cpp-{{ version }}.tar.gz
+    sha1: {{ hash }}
+
+build:
+    number: 0
+    skip: true  # [win and vc<14]
+
+requirements:
+    build:
+        - cmake
+        - make
+        - pkg-config  # [osx]
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+    host:
+        - snappy
+        - xz
+        - zlib
+        - boost>=1.70.0
+        - boost-cpp>=1.70.0
+        - msinttypes  # [win]
+    run:
+        - xz
+        - snappy
+        - zlib
+        - boost>=1.70.0
+        - boost-cpp>=1.70.0
+
+test:
+    commands:
+        - test -f ${PREFIX}/lib/libavrocpp_s.a  # [unix]
+        - conda inspect objects {{ name }}      # [osx]
+        - conda inspect linkages {{ name }}     # [linux]
+
+about:
+  home: http://hadoop.apache.org/avro
+  license: Apache 2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: 'Avro is a serialization and RPC framework.'
+
+
+extra:
+  recipe-maintainers:
+    - mariusvniekerk

--- a/recipes/baton/1da6bc5/build.sh
+++ b/recipes/baton/1da6bc5/build.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -ex
+
+n="$CPU_COUNT"
+
+autoreconf -i
+
+./configure --prefix="$PREFIX" \
+            CFLAGS="-I$PREFIX/include -I$PREFIX/include/irods" \
+            CPPFLAGS="-I$PREFIX/include -I$PREFIX/include/irods" \
+            LDFLAGS="-L$PREFIX/lib -L$PREFIX/lib/irods/externals"
+
+make -j $n
+make install prefix="$PREFIX"

--- a/recipes/baton/1da6bc5/meta.yaml
+++ b/recipes/baton/1da6bc5/meta.yaml
@@ -1,0 +1,105 @@
+{% set version = "2.0.1+1da6bc5bd75b49a2f27d449afeb659cf6ec1b513" %}
+
+package:
+  name: baton-pkg
+  version: "{{ version }}"
+
+about:
+  home: https://github.com/wtsi-npg/baton
+  license: GPL2
+  summary: Client programs and API for use with iRODS (Integrated Rule-Oriented Data System).
+
+build:
+  number: 0
+
+source:
+  - git_url: https://github.com/wtsi-npg/baton.git
+    git_rev: "1da6bc5bd75b49a2f27d449afeb659cf6ec1b513"
+    patches:
+      - selfassign.patch
+
+requirements:
+  build:
+    - {{ compiler("c") }}
+    - clang
+    - clangxx
+    - autoconf
+    - automake>=1.16.2
+    - libtool
+    - make
+    - perl
+    - pkg-config
+  host:
+    - irods-dev ==4.2.7
+    - libjansson-dev
+    - libssl-dev
+    - irods-runtime==4.2.7
+  run:
+    - {{ pin_subpackage("libbaton", exact=True) }}
+    - irods-runtime ==4.2.7
+    - libjansson
+    - libssl
+
+outputs:
+  - name: baton
+    version: {{ version }}
+    requirements:
+      build:
+        - {{ compiler("c") }}
+        - autoconf
+        - automake>=1.16.2
+        - libtool
+        - make
+        - perl
+        - pkg-config
+      host:
+        - irods-dev ==4.2.7
+        - libjansson-dev
+        - libssl-dev
+      run:
+        - {{ pin_subpackage("libbaton", exact=True) }}
+        - irods-runtime ==4.2.7
+        - libjansson
+        - libssl
+    files:
+      - bin/baton-*
+    test:
+      commands:
+        - baton-list --version
+
+  - name: libbaton
+    version: {{ version }}
+    requirements:
+      build:
+        - {{ compiler("c") }}
+        - autoconf
+        - automake>=1.16.2
+        - libtool
+        - make
+        - perl
+        - pkg-config
+      host:
+        - irods-dev ==4.2.7
+        - libjansson-dev
+        - libssl-dev
+      run:
+        - irods-runtime ==4.2.7
+        - libjansson
+        - libssl
+    files:
+      - lib/libbaton.*
+    test:
+      commands:
+        - test -h ${PREFIX}/lib/libbaton.so
+
+  - name: libbaton-dev
+    version: {{ version }}
+    requirements:
+      run:
+        - {{ pin_subpackage("libbaton", exact=True) }}
+    files:
+      - include/baton
+      - lib/pkgconfig/baton.pc
+    test:
+      commands:
+        - test -f ${PREFIX}/include/baton/baton.h

--- a/recipes/baton/1da6bc5/selfassign.patch
+++ b/recipes/baton/1da6bc5/selfassign.patch
@@ -1,0 +1,17 @@
+diff --git a/src/write.c b/src/write.c
+index df58ab6..6ea847c 100644
+--- a/src/write.c
++++ b/src/write.c
+@@ -213,11 +213,10 @@ int create_collection(rcComm_t *conn, rodsPath_t *rods_path, int flags,
+     return error->code;
+ }
+ 
+-int remove_data_object(rcComm_t *conn, rodsPath_t *rods_path, int flags,
++int remove_data_object(rcComm_t *conn, rodsPath_t *rods_path, __attribute__((unused)) int flags,
+                        baton_error_t *error) {
+     dataObjInp_t obj_rm_in;
+     int status;
+-    flags = flags;
+ 
+     init_baton_error(error);
+ 

--- a/recipes/htslib-plugins/201712-irods_4.2.7/build.sh
+++ b/recipes/htslib-plugins/201712-irods_4.2.7/build.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -ex
+
+n="$CPU_COUNT"
+
+pushd plugins
+make IRODS_HOME="$PREFIX" \
+     CC="$GCC" CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
+make install prefix="$PREFIX"
+popd

--- a/recipes/htslib-plugins/201712-irods_4.2.7/meta.yaml
+++ b/recipes/htslib-plugins/201712-irods_4.2.7/meta.yaml
@@ -1,0 +1,79 @@
+{% set gittag = "201712" %}
+{% set version = "201712+irods_4.2.7" %}
+
+package:
+  name: htslib-plugins
+  version: "{{ version }}"
+
+about:
+  home: https://github.com/samtools/htslib
+  license: MIT
+  summary: C library for high-throughput sequencing data formats.
+
+build:
+  number: 0
+
+source:
+  - git_url: https://github.com/samtools/htslib-plugins.git
+    git_rev: {{ gittag }}
+    folder: plugins
+
+requirements:
+  build:
+    - {{ compiler("c") }}
+    - autoconf
+    - automake
+    - make
+    - perl
+  host:
+    - irods-dev >=4.2.7
+    - libbz2-dev
+    - libcurl-dev
+    - libdeflate-dev
+    - libhts-dev
+    - liblzma-dev
+    - libssl-dev
+    - libz-dev
+  run:
+    - libbz2
+    - libcurl
+    - libdeflate
+    - liblzma
+    - libssl
+    - libz
+    - irods-runtime >=4.2.7
+
+outputs:
+  - name: libhts-plugins
+    version: {{ version }}
+    requirements:
+      build:
+        - {{ compiler("c") }}
+        - autoconf
+        - automake
+        - make
+        - perl
+      host:
+        - irods-dev >=4.2.7
+        - libbz2-dev
+        - libcurl-dev
+        - libdeflate-dev
+        - libhts-dev
+        - liblzma-dev
+        - libssl-dev
+        - libz-dev
+      run:
+        - libbz2
+        - libcurl
+        - libdeflate
+        - libhts
+        - liblzma
+        - libssl
+        - libz
+        - irods-runtime >=4.2.7
+    files:
+      - libexec/htslib/hfile_irods.so
+      - libexec/htslib/hfile_mmap.so
+    test:
+      commands:
+        - test -f ${PREFIX}/libexec/htslib/hfile_irods.so

--- a/recipes/irods/4.2.7/build.sh
+++ b/recipes/irods/4.2.7/build.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+set -ex
+
+untar_data() {
+    if [ -e data.tar.gz ]; then
+        tar xz --strip-components=0 --directory="$PREFIX" \
+            --exclude='*.o' --exclude-backups < data.tar.gz
+    elif [ -e data.tar.xz ]; then
+        tar xJ --strip-components=0 --directory="$PREFIX" \
+            --exclude='*.o' --exclude-backups < data.tar.xz
+    fi
+}
+
+unrpm_data() {
+    local rpm="$1"
+    mkdir -p ./tmp
+    pushd tmp
+    rpm2cpio ../"$rpm" | cpio --extract --make-directories
+    popd
+    tar cf - -C ./tmp . | tar xv --strip-components=2 --directory="$PREFIX" \
+                              --exclude='*.o' --exclude-backups
+    rm -r ./tmp
+}
+
+running_in_docker() {
+    if [ -f /.dockerenv ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+install_gcc_ubuntu() {
+    GCC_VERSION=
+    grep precise /etc/lsb-release && GCC_VERSION="4.6"
+    grep xenial  /etc/lsb-release && GCC_VERSION="4.8"
+    grep bionic  /etc/lsb-release && GCC_VERSION="4.8"
+
+    sudo apt-get install -y "g++-$GCC_VERSION" "gcc-$GCC_VERSION"
+
+    sudo update-alternatives --install /usr/bin/gcc gcc "/usr/bin/gcc-$GCC_VERSION" 100
+    sudo update-alternatives --install /usr/bin/g++ g++ "/usr/bin/g++-$GCC_VERSION" 100
+    sudo update-alternatives --set gcc "/usr/bin/gcc-$GCC_VERSION"
+    sudo update-alternatives --set g++ "/usr/bin/g++-$GCC_VERSION"
+}
+
+install_deps_ubuntu() {
+    sudo apt-get install -y autoconf automake help2man make \
+         libtool pkg-config texinfo
+
+    sudo apt-get install -y libjson-perl python-dev
+
+    sudo apt-get install -y libbz2-dev libcurl4-gnutls-dev \
+         libfuse-dev libkrb5-dev libmysqlclient-dev libpam0g-dev \
+         libssl-dev unixodbc-dev libxml2-dev zlib1g-dev
+}
+
+# Requires:
+#
+# sudo subscription-manager register --org="..." --activationkey="..."
+# sudo subscription-manager repos --enable rhel-7-server-extras-rpms
+# sudo subscription-manager repos --enable rhel-7-server-supplementary-rpms
+# sudo subscription-manager repos --enable rhel-7-server-optional-rpms
+
+install_gcc_rhel() {
+    sudo yum install -y gcc-c++
+}
+
+install_deps_rhel() {
+    sudo yum install -y help2man make rpm-build
+
+    sudo yum install -y perl-JSON python-devel
+
+    sudo yum install -y bzip2-devel curl-devel \
+         fuse-devel krb5-devel pam-devel \
+         openssl-devel unixODBC-devel libxml2-devel zlib-devel
+}
+
+export TERM=dumb
+
+if [ -f /etc/lsb-release ]; then
+    if running_in_docker ; then
+        echo "Running in Docker ... skipping package installation"
+#    else
+        #install_gcc_ubuntu
+        #install_deps_ubuntu
+    fi
+
+    export CFLAGs="-I$PREFIX/include"
+    export CCFLAGS="-I$PREFIX/include -Wno-deprecated-declarations"
+    export CXXFLAGS="-I$PREFIX/include -Wno-deprecated-declarations"
+    export LDFLAGS="-L$PREFIX/lib"
+    mkdir build_irods
+    mkdir build_icommands
+    cd build_irods
+
+    git submodule init && git submodule update
+    cmake -D CMAKE_INSTALL_PREFIX=${PREFIX} -D IRODS_EXTERNALS_FULLPATH_CLANG=${BUILD_PREFIX} -D IRODS_EXTERNALS_FULLPATH_CPPZMQ=${PREFIX} -D IRODS_EXTERNALS_FULLPATH_ARCHIVE=${PREFIX} -D IRODS_EXTERNALS_FULLPATH_AVRO=${PREFIX} -D IRODS_EXTERNALS_FULLPATH_BOOST=${PREFIX} -D IRODS_EXTERNALS_FULLPATH_CLANG_RUNTIME=${PREFIX} -D IRODS_EXTERNALS_FULLPATH_ZMQ=${PREFIX} -D IRODS_EXTERNALS_FULLPATH_JANSSON=${PREFIX} -D CMAKE_C_FLAGS="-I$PREFIX/include" -D CMAKE_EXE_LINKER_FLAGS="-Wl,-rpath-link,${PREFIX}/lib -fuse-ld=$LD" \
+	   -D IRODS_LINUX_DISTRIBUTION_NAME='Ubuntu' -D IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR='12' -D IRODS_LINUX_DISTRIBUTION_VERSION_CODENAME='Precise' -D IRODS_EXTERNALS_FULLPATH_CATCH2=${PREFIX} -DCMAKE_AR=$AR -DCMAKE_LINKER=$LD -DCMAKE_SYSROOT=${PREFIX}  ../irods
+    make -j${CPU_COUNT} package
+    #for the icommands
+    cd ..
+    mkdir build
+    cd build
+    ${AR} vx ../build_irods/irods-dev_4.2.7~Precise_amd64.deb
+    untar_data
+    ${AR} vx ../build_irods/irods-runtime_4.2.7~Precise_amd64.deb
+    untar_data
+    cd ../build_icommands
+    cmake -D CMAKE_CXX_FLAGS='-Wno-deprecated-declarations -Wno-unused-command-line-argument' -D CMAKE_INSTALL_PREFIX=${PREFIX} -D IRODS_DIR=$PREFIX/lib/irods/cmake -D CMAKE_EXE_LINKER_FLAGS="-Wl,-rpath-link,${PREFIX}/lib" -D IRODS_LINUX_DISTRIBUTION_NAME='Ubuntu' -D IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR='12' -D IRODS_LINUX_DISTRIBUTION_VERSION_CODENAME='Precise' -DCMAKE_AR=$AR -DCMAKE_LINKER=$LD -D CMAKE_EXE_LINKER_FLAGS="-Wl,-rpath-link,${PREFIX}/lib -fuse-ld=$LD" -DCMAKE_SYSROOT=${PREFIX} ../irods_client_icommands
+    make -j${CPU_COUNT} package
+    cd ../build
+    ${AR} vx ../build_icommands/irods-icommands_4.2.7~Precise_amd64.deb
+    untar_data
+
+fi
+
+if [ -f /etc/redhat-release ]; then
+    if running_in_docker ; then
+        echo "Running in Docker ... skipping package installation"
+    else
+        install_gcc_rhel
+        install_deps_rhel
+    fi
+
+    export CCFLAGS="$PREFIX/include"
+    export LDRFLAGS="$PREFIX/lib"
+    ./packaging/build.sh --verbose icat postgres
+    ./packaging/build.sh --verbose icommands
+
+    cd build
+
+    unrpm_data irods-icommands-4.1.12-64bit-centos[0-9].rpm
+    unrpm_data irods-dev-4.1.12-64bit-centos[0-9].rpm
+fi
+
+# Fix all the absolute symlinks pointing to /usr/include
+perl -le 'use strict; use File::Basename; foreach (@ARGV) { if (my $f = readlink $_) { if ($f =~ m{^/usr/}sm) { unlink $_; symlink(basename($f), $_) } } }' $PREFIX/include/irods/*.hpp

--- a/recipes/irods/4.2.7/conda_build_config.yaml
+++ b/recipes/irods/4.2.7/conda_build_config.yaml
@@ -1,0 +1,8 @@
+
+CFLAGS: >-
+  -fPIC
+  -ffunction-sections
+  -ftree-vectorize
+  -march=x86-64
+  -mtune=generic
+  -pipe

--- a/recipes/irods/4.2.7/icommands.patch
+++ b/recipes/irods/4.2.7/icommands.patch
@@ -1,0 +1,83 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 89a38f0..69ad591 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,12 +1,13 @@
+ cmake_minimum_required(VERSION 3.5.0 FATAL_ERROR) #CPACK_DEBIAN_<COMPONENT>_PACKAGE_NAME
+ include(${CMAKE_SOURCE_DIR}/cmake/RequireOutOfSourceBuild.cmake)
++include(GNUInstallDirs)
+ 
+ find_package(IRODS 4.2.7 EXACT REQUIRED CONFIG)
+ 
+ set(CMAKE_C_COMPILER ${IRODS_EXTERNALS_FULLPATH_CLANG}/bin/clang)
+ set(CMAKE_CXX_COMPILER ${IRODS_EXTERNALS_FULLPATH_CLANG}/bin/clang++)
+ 
+-set(CMAKE_EXE_LINKER_FLAGS_INIT "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
++set(CMAKE_EXE_LINKER_FLAGS_INIT "${CMAKE_EXE_LINKER_FLAGS}")
+ 
+ project(icommands C CXX)
+ 
+@@ -28,12 +29,12 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+ set(CMAKE_INSTALL_RPATH ${IRODS_EXTERNALS_FULLPATH_CLANG_RUNTIME}/lib)
+ set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+ 
+-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
+-set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -stdlib=libc++")
+-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -stdlib=libc++")
+-add_compile_options(-nostdinc++ -Wall -Wextra -Werror -Wno-unused-parameter)
+-link_libraries(c++abi)
+-include_directories(${IRODS_EXTERNALS_FULLPATH_CLANG}/include/c++/v1)
++#set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
++#set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -stdlib=libc++")
++#set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -stdlib=libc++")
++add_compile_options(-Wall -Wextra -Werror -Wno-unused-parameter)
++#link_libraries(c++abi)
++#include_directories(${IRODS_EXTERNALS_FULLPATH_CLANG}/include/c++/v1)
+ 
+ set(
+   IRODS_CLIENT_ICOMMANDS_EXECUTABLES
+@@ -125,7 +126,7 @@ foreach(EXECUTABLE ${IRODS_CLIENT_ICOMMANDS_EXECUTABLES})
+     TARGETS
+     ${EXECUTABLE}
+     RUNTIME
+-    DESTINATION usr/bin
++    DESTINATION ${CMAKE_INSTALL_BINDIR}
+     )
+ 
+   if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos")
+@@ -147,7 +148,7 @@ foreach(EXECUTABLE ${IRODS_CLIENT_ICOMMANDS_EXECUTABLES})
+   install(
+     FILES
+     ${CMAKE_BINARY_DIR}/man/${EXECUTABLE}.1.gz
+-    DESTINATION usr/share/man/man1
++    DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
+     )
+ endforeach()
+ 
+@@ -179,13 +180,13 @@ foreach(IRODS_CLIENT_ICOMMANDS_SCRIPT ${IRODS_CLIENT_ICOMMANDS_SCRIPTS})
+   install(
+     FILES
+     ${CMAKE_BINARY_DIR}/man/${IRODS_CLIENT_ICOMMANDS_SCRIPT}.1.gz
+-    DESTINATION usr/share/man/man1
++    DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
+     )
+ endforeach()
+ 
+ install(
+   DIRECTORY ${CMAKE_SOURCE_DIR}/test
+-  DESTINATION var/lib/irods/clients/icommands
++  DESTINATION ${CMAKE_INSTALL_LOCALSTATEDIR}/lib/irods/clients/icommands
+   )
+ 
+ 
+@@ -194,8 +195,8 @@ if (NOT CPACK_DEBIAN_PACKAGE_VERSION)
+ endif()
+ 
+ set(CPACK_PACKAGE_FILE_NAME "irods-icommands${IRODS_PACKAGE_FILE_NAME_SUFFIX}")
+-set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY OFF)
+-set(CPACK_COMPONENT_INCLUDE_TOPLEVEL_DIRECTORY OFF)
++#set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY OFF)
++#set(CPACK_COMPONENT_INCLUDE_TOPLEVEL_DIRECTORY OFF)
+ set(CPACK_COMPONENTS_GROUPING IGNORE)
+ set(CPACK_PACKAGE_VERSION ${IRODS_VERSION})
+ set(CPACK_PACKAGE_VERSION_MAJOR ${IRODS_VERSION_MAJOR})

--- a/recipes/irods/4.2.7/irods.patch
+++ b/recipes/irods/4.2.7/irods.patch
@@ -1,0 +1,555 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c74f74a5a..2d0a97703 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,6 +1,7 @@
+ cmake_minimum_required(VERSION 3.5.0 FATAL_ERROR) #CPACK_DEBIAN_<COMPONENT>_PACKAGE_NAME
+ include(${CMAKE_SOURCE_DIR}/cmake/RequireOutOfSourceBuild.cmake)
+ 
++
+ if (NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
+   set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build {Debug, Release}." FORCE)
+   message(STATUS "Setting unspecified CMAKE_BUILD_TYPE to '${CMAKE_BUILD_TYPE}'. This is the correct setting for normal builds.")
+@@ -41,10 +42,11 @@ string(REPLACE ";" ", " IRODS_PACKAGE_DEPENDENCIES_STRING "${IRODS_PACKAGE_DEPEN
+ set(CMAKE_C_COMPILER ${IRODS_EXTERNALS_FULLPATH_CLANG}/bin/clang)
+ set(CMAKE_CXX_COMPILER ${IRODS_EXTERNALS_FULLPATH_CLANG}/bin/clang++)
+ 
+-set(CMAKE_EXE_LINKER_FLAGS_INIT "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
++set(CMAKE_EXE_LINKER_FLAGS_INIT "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath-link,${CMAKE_INSTALL_PREFIX}")
+ 
+ project(irods C CXX)
+ 
++include(GNUInstallDirs)
+ set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
+ 
+ if (NOT CPACK_PACKAGING_INSTALL_PREFIX)
+@@ -52,15 +54,16 @@ if (NOT CPACK_PACKAGING_INSTALL_PREFIX)
+   message(STATUS "Setting unspecified CPACK_PACKAGING_INSTALL_PREFIX to '${CPACK_PACKAGING_INSTALL_PREFIX}'. This is the correct setting for normal builds.")
+ endif()
+ 
++set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+-set(CMAKE_INSTALL_RPATH ${IRODS_EXTERNALS_FULLPATH_CLANG_RUNTIME}/lib)
++set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib:${IRODS_EXTERNALS_FULLPATH_CLANG_RUNTIME}/lib)
+ 
+-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -Wl,--export-dynamic") # export-dynamic so stacktrace entries from executables have function names
+-set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -stdlib=libc++ -Wl,-z,defs")
+-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -stdlib=libc++ -Wl,-z,defs")
+-add_compile_options(-nostdinc++ -Wall -Wextra -Werror -Wno-unused-function -Wno-unused-parameter)
+-link_libraries(c++abi)
+-include_directories(${IRODS_EXTERNALS_FULLPATH_CLANG}/include/c++/v1)
++set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--export-dynamic") # export-dynamic so stacktrace entries from executables have function names
++set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-z,defs")
++set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,defs")
++add_compile_options(-Wall -Wextra -Wno-unused-function -Wno-unused-parameter)
++#link_libraries(c++abi)
++#include_directories(${IRODS_EXTERNALS_FULLPATH_CLANG}/include/c++/v1)
+ 
+ find_package(Threads REQUIRED)
+ find_package(OpenSSL REQUIRED)
+@@ -85,31 +88,33 @@ set(IRODS_COMPILE_DEFINITIONS ${IRODS_PLATFORM_STRING} _LARGEFILE_SOURCE _FILE_O
+ 
+ if (NOT IRODS_LINUX_DISTRIBUTION_NAME)
+   execute_process(
+-    COMMAND "python" "-c" "from __future__ import print_function; import platform; print(platform.linux_distribution()[0].split()[0].strip().lower(), end='')"
++    COMMAND "lsb_release" "-i" "-s"
+     RESULT_VARIABLE IRODS_EXECUTE_PROCESS_RESULT_LINUX_DISTRIBUTION_NAME
+     OUTPUT_VARIABLE IRODS_LINUX_DISTRIBUTION_NAME
+     )
++  string(STRIP ${IRODS_LINUX_DISTRIBUTION_NAME} IRODS_LINUX_DISTRIBUTION_NAME)
+   if (NOT ${IRODS_EXECUTE_PROCESS_RESULT_LINUX_DISTRIBUTION_NAME} STREQUAL "0")
+     message(FATAL_ERROR "Linux platform name detection failed\n${IRODS_EXECUTE_PROCESS_RESULT_LINUX_DISTRIBUTION_NAME}")
+   endif()
+-  set(IRODS_LINUX_DISTRIBUTION_NAME ${IRODS_LINUX_DISTRIBUTION_NAME} CACHE STRING "Linux distribution name, e.g. {ubuntu, centos, ...}." FORCE)
++  set(IRODS_LINUX_DISTRIBUTION_NAME ${IRODS_LINUX_DISTRIBUTION_NAME} CACHE STRING "Linux distribution name, e.g. {Ubuntu, CentOS, ...}." FORCE)
+   message(STATUS "Setting unspecified IRODS_LINUX_DISTRIBUTION_NAME to '${IRODS_LINUX_DISTRIBUTION_NAME}'")
+ endif()
+ 
+ if (NOT IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR)
+   execute_process(
+-    COMMAND "python" "-c" "from __future__ import print_function; import platform; print(platform.linux_distribution()[1].strip().lower().split('.')[0], end='')"
++    COMMAND "lsb_release" "-r" "-s"
+     RESULT_VARIABLE IRODS_EXECUTE_PROCESS_RESULT_LINUX_DISTRIBUTION_VERSION_MAJOR
+     OUTPUT_VARIABLE IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR
+     )
++  string(STRIP ${IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR} IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR)
+   if (NOT ${IRODS_EXECUTE_PROCESS_RESULT_LINUX_DISTRIBUTION_VERSION_MAJOR} STREQUAL "0")
+     message(FATAL_ERROR "Linux platform name detection failed\n${IRODS_EXECUTE_PROCESS_RESULT_LINUX_DISTRIBUTION_VERSION_MAJOR}")
+   endif()
+-  set(IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR ${IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR} CACHE STRING "Linux distribution name, e.g. {ubuntu, centos, ...}." FORCE)
++  set(IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR ${IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR} CACHE STRING "Linux distribution name, e.g. {Ubuntu, CentOS, ...}." FORCE)
+   message(STATUS "Setting unspecified IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR to '${IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR}'")
+ endif()
+ 
+-if(IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "ubuntu" OR IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "debian")
++if(IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "Ubuntu" OR IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "Debian")
+   if (NOT IRODS_LINUX_DISTRIBUTION_VERSION_CODENAME)
+     execute_process(
+       COMMAND "lsb_release" "-s" "-c"
+@@ -126,13 +131,13 @@ if(IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "ubuntu" OR IRODS_LINUX_DISTRIBUTION_N
+ endif()
+ 
+ if (NOT CPACK_GENERATOR)
+-  if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "arch")
++	if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "Arch")
+     set(CPACK_GENERATOR TGZ CACHE STRING "CPack generator to use, e.g. {DEB, RPM, TGZ}." FORCE)
+     message(STATUS "Setting unspecified CPACK_GENERATOR to ${CPACK_GENERATOR}. This is the correct setting for normal builds.")
+-  elseif(IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "ubuntu" OR IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "debian")
++  elseif(IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "Ubuntu" OR IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "Debian")
+     set(CPACK_GENERATOR DEB CACHE STRING "CPack generator to use, e.g. {DEB, RPM, TGZ}." FORCE)
+     message(STATUS "Setting unspecified CPACK_GENERATOR to ${CPACK_GENERATOR}. This is the correct setting for normal builds.")
+-  elseif(IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos" OR IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "opensuse" OR IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "fedora")
++  elseif(IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "CentOS" OR IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "openSUSE project" OR IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "Fedora" OR IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "RedHatEnterpriseServer")
+     set(CPACK_GENERATOR RPM CACHE STRING "CPack generator to use, e.g. {DEB, RPM, TGZ}." FORCE)
+     message(STATUS "Setting unspecified CPACK_GENERATOR to ${CPACK_GENERATOR}. This is the correct setting for normal builds.")
+   else()
+@@ -1374,8 +1379,8 @@ set_property(TARGET genOSAuth PROPERTY CXX_STANDARD ${IRODS_CXX_STANDARD})
+ target_compile_definitions(genOSAuth PRIVATE ${IRODS_COMPILE_DEFINITIONS})
+ target_compile_options(genOSAuth PRIVATE -Wno-write-strings)
+ 
+-set(IRODS_HOME_DIRECTORY var/lib/irods)
+-set(IRODS_PLUGINS_DIRECTORY usr/lib/irods/plugins)
++set(IRODS_HOME_DIRECTORY ${CMAKE_INSTALL_LOCALSTATEDIR}/lib/irods)
++set(IRODS_PLUGINS_DIRECTORY ${CMAKE_INSTALL_LIBDIR}/irods/plugins)
+ 
+ add_subdirectory(plugins/api)
+ add_subdirectory(plugins/auth)
+@@ -1391,8 +1396,8 @@ include(${CMAKE_SOURCE_DIR}/cmake/development_library.cmake)
+ include(${CMAKE_SOURCE_DIR}/cmake/runtime_library.cmake)
+ include(${CMAKE_SOURCE_DIR}/cmake/server.cmake)
+ 
+-set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY OFF)
+-set(CPACK_COMPONENT_INCLUDE_TOPLEVEL_DIRECTORY OFF)
++#set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY ON)
++#set(CPACK_COMPONENT_INCLUDE_TOPLEVEL_DIRECTORY ON)
+ set(CPACK_COMPONENTS_GROUPING IGNORE)
+ set(CPACK_PACKAGE_VERSION ${IRODS_VERSION})
+ set(CPACK_PACKAGE_VERSION_MAJOR ${IRODS_VERSION_MAJOR})
+@@ -1431,13 +1436,13 @@ set(CPACK_DEBIAN_${IRODS_PACKAGE_COMPONENT_POSTGRES_NAME_UPPERCASE}_PACKAGE_DEPE
+ set(CPACK_DEBIAN_${IRODS_PACKAGE_COMPONENT_POSTGRES_NAME_UPPERCASE}_PACKAGE_CONTROL_EXTRA "${CMAKE_SOURCE_DIR}/plugins/database/packaging/preinst;${CMAKE_SOURCE_DIR}/plugins/database/packaging/postinst;${CMAKE_SOURCE_DIR}/plugins/database/packaging/postrm;")
+ 
+ set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_POSTGRES_NAME}_PACKAGE_NAME "irods-database-plugin-postgres")
+-if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos")
++if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "CentOS")
+   if (IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR STREQUAL "6" OR IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR STREQUAL "7")
+     set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_POSTGRES_NAME}_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-server = ${IRODS_VERSION}, unixODBC, postgresql, authd, postgresql-odbc")
+   else()
+     message(FATAL "Unsupported CentOS major version: ${IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR}")
+   endif()
+-elseif (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "opensuse")
++elseif (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "openSUSE project")
+   set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_POSTGRES_NAME}_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-server = ${IRODS_VERSION}, unixODBC, postgresql, psqlODBC")
+ endif()
+ set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_POSTGRES_NAME}_PRE_INSTALL_SCRIPT_FILE "${CMAKE_SOURCE_DIR}/plugins/database/packaging/preinst")
+@@ -1446,7 +1451,7 @@ set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_POSTGRES_NAME}_POST_UNINSTALL_SCRIPT_FIL
+ 
+ # mysql
+ set(CPACK_DEBIAN_${IRODS_PACKAGE_COMPONENT_MYSQL_NAME_UPPERCASE}_PACKAGE_NAME "irods-database-plugin-mysql")
+-if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "ubuntu" AND IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR STREQUAL "16")
++if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "Ubuntu" AND IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR STREQUAL "16")
+   set(CPACK_DEBIAN_${IRODS_PACKAGE_COMPONENT_MYSQL_NAME_UPPERCASE}_PACKAGE_DEPENDS "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-server (= ${CPACK_DEBIAN_PACKAGE_VERSION}), unixodbc, mysql-client, libc6")
+ else()
+   set(CPACK_DEBIAN_${IRODS_PACKAGE_COMPONENT_MYSQL_NAME_UPPERCASE}_PACKAGE_DEPENDS "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-server (= ${CPACK_DEBIAN_PACKAGE_VERSION}), unixodbc, libmyodbc, mysql-client, libc6")
+@@ -1454,13 +1459,13 @@ endif()
+ set(CPACK_DEBIAN_${IRODS_PACKAGE_COMPONENT_MYSQL_NAME_UPPERCASE}_PACKAGE_CONTROL_EXTRA "${CMAKE_SOURCE_DIR}/plugins/database/packaging/preinst;${CMAKE_SOURCE_DIR}/plugins/database/packaging/postinst;${CMAKE_SOURCE_DIR}/plugins/database/packaging/postrm;")
+ 
+ set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_MYSQL_NAME}_PACKAGE_NAME "irods-database-plugin-mysql")
+-if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos")
++if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "CentOS")
+   if (IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR STREQUAL "6" OR IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR STREQUAL "7")
+     set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_MYSQL_NAME}_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-server = ${IRODS_VERSION}, mysql, unixODBC, mysql-connector-odbc")
+   else()
+     message(FATAL "Unsupported CentOS major version: ${IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR}")
+   endif()
+-elseif (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "opensuse")
++elseif (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "openSUSE project")
+   set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_MYSQL_NAME}_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-server = ${IRODS_VERSION}, mysql-client, unixODBC, MyODBC-unixODBC")
+ endif()
+ set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_MYSQL_NAME}_PRE_INSTALL_SCRIPT_FILE "${CMAKE_SOURCE_DIR}/plugins/database/packaging/preinst")
+@@ -1473,7 +1478,7 @@ set(CPACK_DEBIAN_${IRODS_PACKAGE_COMPONENT_ORACLE_NAME_UPPERCASE}_PACKAGE_DEPEND
+ set(CPACK_DEBIAN_${IRODS_PACKAGE_COMPONENT_ORACLE_NAME_UPPERCASE}_PACKAGE_CONTROL_EXTRA "${CMAKE_SOURCE_DIR}/plugins/database/packaging/preinst;${CMAKE_SOURCE_DIR}/plugins/database/packaging/postinst;${CMAKE_SOURCE_DIR}/plugins/database/packaging/postrm;")
+ 
+ set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_ORACLE_NAME}_PACKAGE_NAME "irods-database-plugin-oracle")
+-if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos")
++if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "CentOS")
+   if (IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR STREQUAL "6")
+     set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_ORACLE_NAME}_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-server = ${IRODS_VERSION}, unixODBC")
+   elseif (IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR STREQUAL "7")
+@@ -1481,7 +1486,7 @@ if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos")
+   else()
+     message(FATAL "Unsupported CentOS major version: ${IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR}")
+   endif()
+-elseif (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "opensuse")
++elseif (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "openSUSE project")
+   set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_ORACLE_NAME}_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-server = ${IRODS_VERSION}, unixODBC")
+ endif()
+ set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_ORACLE_NAME}_PRE_INSTALL_SCRIPT_FILE "${CMAKE_SOURCE_DIR}/plugins/database/packaging/preinst")
+@@ -1538,20 +1543,20 @@ install(
+   )
+ 
+ 
+-set(IRODS_INCLUDE_DIRS usr/include/irods)
++set(IRODS_INCLUDE_DIRS include/irods)
+ 
+ include(CMakePackageConfigHelpers)
+ configure_package_config_file(
+   ${CMAKE_SOURCE_DIR}/cmake/IRODSConfig.cmake.not_yet_installed.in
+   ${CMAKE_BINARY_DIR}/IRODSConfig.cmake.not_yet_installed # suffix prevents cmake's find_package() from using this copy of the file
+-  INSTALL_DESTINATION usr/lib/irods/cmake
++  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/irods/cmake
+   PATH_VARS IRODS_INCLUDE_DIRS
+   )
+ 
+ install(
+   FILES
+   ${CMAKE_BINARY_DIR}/IRODSConfig.cmake.not_yet_installed
+-  DESTINATION usr/lib/irods/cmake
++  DESTINATION ${CMAKE_INSTALL_LIBDIR}/irods/cmake
+   COMPONENT ${IRODS_PACKAGE_COMPONENT_DEVELOPMENT_NAME}
+   RENAME IRODSConfig.cmake
+   )
+@@ -1565,7 +1570,7 @@ write_basic_package_version_file(
+ install(
+   FILES
+   ${CMAKE_BINARY_DIR}/IRODSConfigVersion.cmake
+-  DESTINATION usr/lib/irods/cmake
++  DESTINATION ${CMAKE_INSTALL_LIBDIR}/irods/cmake
+   COMPONENT ${IRODS_PACKAGE_COMPONENT_DEVELOPMENT_NAME}
+   )
+ 
+diff --git a/cmake/development_library.cmake b/cmake/development_library.cmake
+index ac695fdfc..fe176dec0 100644
+--- a/cmake/development_library.cmake
++++ b/cmake/development_library.cmake
+@@ -5,7 +5,7 @@ install(
+   TARGETS
+     RodsAPIs
+   ARCHIVE
+-    DESTINATION usr/lib
++    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     COMPONENT ${IRODS_PACKAGE_COMPONENT_DEVELOPMENT_NAME}
+   )
+ 
+@@ -551,7 +551,7 @@ install(
+   ${IRODS_SERVER_ICAT_INCLUDE_HEADERS}
+   ${IRODS_SERVER_RE_INCLUDE_HEADERS}
+   ${IRODS_SERVER_DRIVERS_INCLUDE_HEADERS}
+-  DESTINATION usr/include/irods
++  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/irods
+   COMPONENT ${IRODS_PACKAGE_COMPONENT_DEVELOPMENT_NAME}
+   )
+ 
+@@ -566,7 +566,7 @@ install(
+ # NOTE: The trailing slash in the "DIRECTORY" argument is significant. DO NOT REMOVE IT!
+ install(
+   DIRECTORY ${CMAKE_SOURCE_DIR}/lib/filesystem/include/
+-  DESTINATION usr/include/irods
++  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/irods
+   COMPONENT ${IRODS_PACKAGE_COMPONENT_DEVELOPMENT_NAME}
+   FILES_MATCHING
+     PATTERN */filesystem.hpp
+@@ -595,7 +595,7 @@ install(
+ # NOTE: The trailing slash in the "DIRECTORY" argument is significant. DO NOT REMOVE IT!
+ install(
+   DIRECTORY ${CMAKE_SOURCE_DIR}/lib/core/include/transport/
+-  DESTINATION usr/include/irods/transport
++  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/irods/transport
+   COMPONENT ${IRODS_PACKAGE_COMPONENT_DEVELOPMENT_NAME}
+   FILES_MATCHING
+     PATTERN */transport/transport.hpp
+@@ -606,7 +606,7 @@ install(
+ install(
+   EXPORT
+   IRODSTargets
+-  DESTINATION usr/lib/irods/cmake
++  DESTINATION ${CMAKE_INSTALL_LIBDIR}/irods/cmake
+   COMPONENT ${IRODS_PACKAGE_COMPONENT_DEVELOPMENT_NAME}
+   )
+ 
+diff --git a/cmake/runtime_library.cmake b/cmake/runtime_library.cmake
+index 408c27fe0..45d60f58a 100644
+--- a/cmake/runtime_library.cmake
++++ b/cmake/runtime_library.cmake
+@@ -6,7 +6,7 @@ install(
+   irods_server
+   EXPORT IRODSTargets
+   LIBRARY
+-  DESTINATION usr/lib
++  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   COMPONENT ${IRODS_PACKAGE_COMPONENT_RUNTIME_NAME}
+   )
+ 
+diff --git a/cmake/server.cmake b/cmake/server.cmake
+index 4a032ecd9..8efa96a0c 100644
+--- a/cmake/server.cmake
++++ b/cmake/server.cmake
+@@ -8,7 +8,7 @@ install(
+   irodsXmsgServer
+   hostname_resolves_to_local_address
+   RUNTIME
+-  DESTINATION usr/sbin
++  DESTINATION ${CMAKE_INSTALL_SBINDIR}
+   COMPONENT ${IRODS_PACKAGE_COMPONENT_SERVER_NAME}
+   )
+ 
+@@ -26,7 +26,7 @@ install(
+ 
+ install(
+   DIRECTORY
+-  DESTINATION etc/irods
++  DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/irods
+   COMPONENT ${IRODS_PACKAGE_COMPONENT_SERVER_NAME}
+   )
+ 
+@@ -60,12 +60,12 @@ install(
+ install(
+   FILES
+   ${CMAKE_SOURCE_DIR}/packaging/irods
+-  DESTINATION etc/init.d
++  DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/init.d
+   COMPONENT ${IRODS_PACKAGE_COMPONENT_SERVER_NAME}
+   PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+   )
+ 
+-set(IRODS_DOC_DIR usr/share/doc/irods)
++set(IRODS_DOC_DIR ${CMAKE_INSTALL_DOCDIR})
+ 
+ install(
+   FILES
+@@ -145,7 +145,7 @@ install(
+   TARGETS
+   irodsPamAuthCheck
+   RUNTIME
+-  DESTINATION usr/sbin
++  DESTINATION ${CMAKE_INSTALL_SBINDIR}
+   COMPONENT ${IRODS_PACKAGE_COMPONENT_SERVER_NAME}
+   PERMISSIONS SETUID OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+   )
+@@ -154,7 +154,7 @@ install(
+   TARGETS
+   genOSAuth
+   RUNTIME
+-  DESTINATION var/lib/irods/clients/bin
++  DESTINATION ${CMAKE_INSTALL_LOCALSTATEDIR}/lib/irods/clients/bin
+   COMPONENT ${IRODS_PACKAGE_COMPONENT_SERVER_NAME}
+   )
+ 
+@@ -182,9 +182,9 @@ endif()
+ 
+ 
+ set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_SERVER_NAME}_PACKAGE_NAME "irods-server")
+-if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos")
++if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "CentOS")
+   set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_SERVER_NAME}_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime = ${IRODS_VERSION}, irods-icommands = ${IRODS_VERSION}, openssl, python, python-psutil, python-requests, python-jsonschema")
+-elseif (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "opensuse")
++elseif (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "openSUSE project")
+   set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_SERVER_NAME}_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime = ${IRODS_VERSION}, irods-icommands = ${IRODS_VERSION}, libopenssl1_0_0, python, openssl, python-psutil, python-requests, python-jsonschema")
+ endif()
+ set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_SERVER_NAME}_PRE_INSTALL_SCRIPT_FILE "${CMAKE_SOURCE_DIR}/preinst")
+diff --git a/lib/core/include/connection_pool.hpp b/lib/core/include/connection_pool.hpp
+index aaaf4a082..d7938710e 100644
+--- a/lib/core/include/connection_pool.hpp
++++ b/lib/core/include/connection_pool.hpp
+@@ -8,6 +8,7 @@
+ #include <mutex>
+ #include <atomic>
+ #include <string>
++#include <functional>
+ 
+ namespace irods
+ {
+diff --git a/lib/core/include/dstream.hpp b/lib/core/include/dstream.hpp
+index 6348522b8..354787ac3 100644
+--- a/lib/core/include/dstream.hpp
++++ b/lib/core/include/dstream.hpp
+@@ -11,6 +11,7 @@
+ #include <stdexcept>
+ #include <algorithm>
+ #include <utility>
++#include <cstring>
+ 
+ namespace irods {
+ namespace experimental {
+diff --git a/unit_tests/cmake/test_config/irods_connection_pool.cmake b/unit_tests/cmake/test_config/irods_connection_pool.cmake
+index 9d79f8313..982e68ee6 100644
+--- a/unit_tests/cmake/test_config/irods_connection_pool.cmake
++++ b/unit_tests/cmake/test_config/irods_connection_pool.cmake
+@@ -14,4 +14,4 @@ set(IRODS_TEST_INCLUDE_PATH ${CMAKE_BINARY_DIR}/lib/core/include
+  
+ set(IRODS_TEST_LINK_LIBRARIES irods_common
+                               irods_client
+-                              c++abi)
++                              )
+diff --git a/unit_tests/cmake/test_config/irods_dstream.cmake b/unit_tests/cmake/test_config/irods_dstream.cmake
+index ea4610924..a21af3b31 100644
+--- a/unit_tests/cmake/test_config/irods_dstream.cmake
++++ b/unit_tests/cmake/test_config/irods_dstream.cmake
+@@ -16,4 +16,4 @@ set(IRODS_TEST_INCLUDE_PATH ${CMAKE_BINARY_DIR}/lib/core/include
+  
+ set(IRODS_TEST_LINK_LIBRARIES irods_common
+                               irods_client
+-                              c++abi)
++                              )
+diff --git a/unit_tests/cmake/test_config/irods_filesystem.cmake b/unit_tests/cmake/test_config/irods_filesystem.cmake
+index 755137edb..9e4a4da1c 100644
+--- a/unit_tests/cmake/test_config/irods_filesystem.cmake
++++ b/unit_tests/cmake/test_config/irods_filesystem.cmake
+@@ -21,4 +21,4 @@ set(IRODS_TEST_LINK_LIBRARIES irods_common
+                               irods_plugin_dependencies
+                               ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_filesystem.so
+                               ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_system.so
+-                              c++abi)
++                              )
+diff --git a/unit_tests/cmake/test_config/irods_hierarchy_parser.cmake b/unit_tests/cmake/test_config/irods_hierarchy_parser.cmake
+index e2fb9fef3..7d11624fa 100644
+--- a/unit_tests/cmake/test_config/irods_hierarchy_parser.cmake
++++ b/unit_tests/cmake/test_config/irods_hierarchy_parser.cmake
+@@ -8,5 +8,4 @@ set(IRODS_TEST_INCLUDE_PATH ${CMAKE_BINARY_DIR}/lib/core/include
+                             ${IRODS_EXTERNALS_FULLPATH_CATCH2}/include
+                             ${IRODS_EXTERNALS_FULLPATH_BOOST}/include)
+  
+-set(IRODS_TEST_LINK_LIBRARIES irods_common
+-                              c++abi)
++set(IRODS_TEST_LINK_LIBRARIES irods_common)
+diff --git a/unit_tests/cmake/test_config/irods_linked_list_iterator.cmake b/unit_tests/cmake/test_config/irods_linked_list_iterator.cmake
+index e243cb604..d71f9799a 100644
+--- a/unit_tests/cmake/test_config/irods_linked_list_iterator.cmake
++++ b/unit_tests/cmake/test_config/irods_linked_list_iterator.cmake
+@@ -15,4 +15,4 @@ set(IRODS_TEST_INCLUDE_PATH ${CMAKE_SOURCE_DIR}/lib/api/include
+  
+ set(IRODS_TEST_LINK_LIBRARIES irods_server
+                               ${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_system.so
+-                              c++abi)
++                              )
+diff --git a/unit_tests/cmake/test_config/irods_logical_paths_and_special_characters.cmake b/unit_tests/cmake/test_config/irods_logical_paths_and_special_characters.cmake
+index b7c69b889..b3b93e5f9 100644
+--- a/unit_tests/cmake/test_config/irods_logical_paths_and_special_characters.cmake
++++ b/unit_tests/cmake/test_config/irods_logical_paths_and_special_characters.cmake
+@@ -14,4 +14,4 @@ set(IRODS_TEST_INCLUDE_PATH ${CMAKE_BINARY_DIR}/lib/core/include
+  
+ set(IRODS_TEST_LINK_LIBRARIES irods_common
+                               irods_client
+-                              c++abi)
++                              )
+diff --git a/unit_tests/cmake/test_config/irods_query_builder.cmake b/unit_tests/cmake/test_config/irods_query_builder.cmake
+index f81431f80..d077ff330 100644
+--- a/unit_tests/cmake/test_config/irods_query_builder.cmake
++++ b/unit_tests/cmake/test_config/irods_query_builder.cmake
+@@ -14,4 +14,4 @@ set(IRODS_TEST_INCLUDE_PATH ${CMAKE_BINARY_DIR}/lib/core/include
+  
+ set(IRODS_TEST_LINK_LIBRARIES irods_common
+                               irods_client
+-                              c++abi)
++                              )
+diff --git a/unit_tests/src/filesystem/test_filesystem.cpp b/unit_tests/src/filesystem/test_filesystem.cpp
+index 9bc6901c9..e80b1b341 100644
+--- a/unit_tests/src/filesystem/test_filesystem.cpp
++++ b/unit_tests/src/filesystem/test_filesystem.cpp
+@@ -12,7 +12,7 @@
+ //   - https://en.cppreference.com/w/Cppreference:Copyright/GDFL
+ //
+ 
+-#include "catch.hpp"
++#include "catch2/catch.hpp"
+ 
+ #include "filesystem/filesystem.hpp"
+ #include "rodsClient.h"
+diff --git a/unit_tests/src/filesystem/test_path.cpp b/unit_tests/src/filesystem/test_path.cpp
+index 1b2f7d8a5..589db86d1 100644
+--- a/unit_tests/src/filesystem/test_path.cpp
++++ b/unit_tests/src/filesystem/test_path.cpp
+@@ -12,7 +12,7 @@
+ //   - https://en.cppreference.com/w/Cppreference:Copyright/GDFL
+ //
+ 
+-#include "catch.hpp"
++#include "catch2/catch.hpp"
+ 
+ #include "filesystem/path.hpp"
+ 
+@@ -20,6 +20,7 @@
+ #include <vector>
+ #include <utility>
+ #include <algorithm>
++#include <cstring>
+ 
+ namespace fs = irods::experimental::filesystem;
+ 
+diff --git a/unit_tests/src/irods_error_enum_matcher.hpp b/unit_tests/src/irods_error_enum_matcher.hpp
+index c24eb04c9..d2a22ecfc 100644
+--- a/unit_tests/src/irods_error_enum_matcher.hpp
++++ b/unit_tests/src/irods_error_enum_matcher.hpp
+@@ -1,4 +1,4 @@
+-#include "catch.hpp"
++#include "catch2/catch.hpp"
+ 
+ #include "rodsErrorTable.h"
+ #include <boost/format.hpp>
+diff --git a/unit_tests/src/main.cpp b/unit_tests/src/main.cpp
+index 0c7c351f4..62bf7476a 100644
+--- a/unit_tests/src/main.cpp
++++ b/unit_tests/src/main.cpp
+@@ -1,2 +1,2 @@
+ #define CATCH_CONFIG_MAIN
+-#include "catch.hpp"
++#include "catch2/catch.hpp"
+diff --git a/unit_tests/src/test_connection_pool.cpp b/unit_tests/src/test_connection_pool.cpp
+index 9b65ded65..e4ee019fe 100644
+--- a/unit_tests/src/test_connection_pool.cpp
++++ b/unit_tests/src/test_connection_pool.cpp
+@@ -1,4 +1,4 @@
+-#include "catch.hpp"
++#include "catch2/catch.hpp"
+ 
+ #include "getRodsEnv.h"
+ #include "connection_pool.hpp"
+diff --git a/unit_tests/src/test_dstream.cpp b/unit_tests/src/test_dstream.cpp
+index 99845e626..1a8d065cb 100644
+--- a/unit_tests/src/test_dstream.cpp
++++ b/unit_tests/src/test_dstream.cpp
+@@ -1,4 +1,4 @@
+-#include "catch.hpp"
++#include "catch2/catch.hpp"
+ 
+ #include "rodsClient.h"
+ #include "connection_pool.hpp"
+diff --git a/unit_tests/src/test_irods_hierarchy_parser.cpp b/unit_tests/src/test_irods_hierarchy_parser.cpp
+index 1b54727ec..5545cab02 100644
+--- a/unit_tests/src/test_irods_hierarchy_parser.cpp
++++ b/unit_tests/src/test_irods_hierarchy_parser.cpp
+@@ -1,4 +1,4 @@
+-#include "catch.hpp"
++#include "catch2/catch.hpp"
+ 
+ #include "irods_error_enum_matcher.hpp"
+ #include "irods_exception.hpp"
+diff --git a/unit_tests/src/test_irods_linked_list_iterator.cpp b/unit_tests/src/test_irods_linked_list_iterator.cpp
+index a3ada8758..9fcc3729f 100644
+--- a/unit_tests/src/test_irods_linked_list_iterator.cpp
++++ b/unit_tests/src/test_irods_linked_list_iterator.cpp
+@@ -1,4 +1,4 @@
+-#include "catch.hpp"
++#include "catch2/catch.hpp"
+ 
+ #include "irods_linked_list_iterator.hpp"
+ #include "objInfo.h"
+diff --git a/unit_tests/src/test_logical_paths_and_special_characters.cpp b/unit_tests/src/test_logical_paths_and_special_characters.cpp
+index b2a39f622..e2459b15e 100644
+--- a/unit_tests/src/test_logical_paths_and_special_characters.cpp
++++ b/unit_tests/src/test_logical_paths_and_special_characters.cpp
+@@ -1,4 +1,4 @@
+-#include "catch.hpp"
++#include "catch2/catch.hpp"
+ 
+ #include "getRodsEnv.h"
+ #include "rodsPath.h"
+diff --git a/unit_tests/src/test_query_builder.cpp b/unit_tests/src/test_query_builder.cpp
+index e1f41558d..0b2f76a04 100644
+--- a/unit_tests/src/test_query_builder.cpp
++++ b/unit_tests/src/test_query_builder.cpp
+@@ -1,4 +1,4 @@
+-#include "catch.hpp"
++#include "catch2/catch.hpp"
+ 
+ #include "getRodsEnv.h"
+ #include "rcConnect.h"

--- a/recipes/irods/4.2.7/meta.yaml
+++ b/recipes/irods/4.2.7/meta.yaml
@@ -1,0 +1,157 @@
+{% set version = "4.2.7" %}
+
+package:
+  name: irods
+  version: "{{ version }}"
+
+about:
+  home: https://irods.org
+  license: BSD
+  summary: "Open Source Data Management Software."
+
+build:
+  number: 5
+
+source:
+  - git_url: https://github.com/irods/irods.git
+    git_rev: "{{ version }}"
+    patches:
+      - irods.patch
+    folder: irods
+  - git_url: https://github.com/irods/irods_client_icommands.git
+    git_rev: "{{ version }}"
+    patches:
+      - icommands.patch
+    folder: irods_client_icommands
+
+requirements:
+  build:
+    - cmake
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - clang==8.0.1
+    - clangxx==8.0.1
+    - make
+  host:
+    - libssl-dev
+    - cppzmq
+    - libarchive
+    - avrocpp
+    - boost-cpp>=1.73.0
+    - zeromq
+    - libpam
+    - unixodbc
+    - jansson
+    - catch2
+    - krb5
+  run:
+    - libssl
+    - cppzmq
+    - libarchive
+    - avrocpp
+    - boost-cpp>=1.73.0
+    - zeromq
+    - krb5
+
+outputs:
+  - name: irods-runtime
+    version: {{ version }}
+    requirements:
+      host:
+        - libssl-dev
+      run:
+        - libssl
+        - boost-cpp>=1.73.0
+        - avrocpp
+        - jansson
+        - zeromq
+        - krb5
+    files:
+      - lib/irods/plugins
+      - lib/libirods_client.so
+      - lib/libirods_client.so.4.2.7
+      - lib/libirods_common.so
+      - lib/libirods_common.so.4.2.7
+      - lib/libirods_plugin_dependencies.so
+      - lib/libirods_plugin_dependencies.so.4.2.7
+      - lib/libirods_server.so
+      - lib/libirods_server.so.4.2.7
+
+  - name: irods-dev
+    version: {{ version }}
+    requirements:
+      run:
+        - {{ pin_subpackage("irods-runtime", exact=True) }}
+    files:
+      - include/irods
+      - lib/irods/externals
+      - lib/libirods_client_api.a
+      - lib/libirods_client_plugins.a
+      - lib/libirods_client_api_table.a
+      - lib/libirods_client_core.a
+      - lib/libirods_client.a
+      - lib/libRodsAPIs.a
+      - lib/libirods_server.a
+      - share/irods
+
+  - name: irods-icommands
+    version: {{ version }}
+    requirements:
+      run:
+        - {{ pin_subpackage("irods-runtime", exact=True) }}
+        - libssl
+        - boost-cpp>=1.73.0
+        - avrocpp
+        - jansson
+        - zeromq
+    files:
+      - bin/iadmin
+      - bin/ibun
+      - bin/ichksum
+      - bin/ichmod
+      - bin/icp
+      - bin/idbug
+      - bin/ienv
+      - bin/ierror
+      - bin/iexecmd
+      - bin/iexit
+      - bin/ifsck
+      - bin/iget
+      - bin/igroupadmin
+      - bin/ihelp
+      - bin/iinit
+      - bin/ils
+      - bin/ilsresc
+      - bin/imcoll
+      - bin/imeta
+      - bin/imiscsvrinfo
+      - bin/imkdir
+      - bin/imv
+      - bin/ipasswd
+      - bin/iphybun
+      - bin/iphymv
+      - bin/ips
+      - bin/iput
+      - bin/ipwd
+      - bin/iqdel
+      - bin/iqmod
+      - bin/iqmod
+      - bin/iqstat
+      - bin/iquest
+      - bin/iquota
+      - bin/irepl
+      - bin/irm
+      - bin/irmtrash
+      - bin/irsync
+      - bin/irule
+      - bin/iscan
+      - bin/isysmeta
+      - bin/iticket
+      - bin/itrim
+      - bin/iuserinfo
+      - bin/ixmsg
+      - bin/izonereport
+
+    test:
+      commands:
+        - ienv

--- a/recipes/libmaus2/2.0.420-3/build.sh
+++ b/recipes/libmaus2/2.0.420-3/build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -ex
+
+n="$CPU_COUNT"
+
+./configure --prefix="$PREFIX" \
+            --with-gnutls \
+            --with-nettle \
+            --with-io_lib \
+            --with-irods=yes \
+            CPPFLAGS="-I$PREFIX/include" \
+            LDFLAGS="-L$PREFIX/lib -L$PREFIX/lib/irods/externals" \
+            LIBS="-lRodsAPIs -lrt"
+
+make -j $n CPPFLAGS="-I$PREFIX/include" \
+     LDFLAGS="-Wl,-rpath-link,$PREFIX/lib -L$PREFIX/lib -L$PREFIX/lib/irods/externals"
+make install prefix="$PREFIX"

--- a/recipes/libmaus2/2.0.420-3/meta.yaml
+++ b/recipes/libmaus2/2.0.420-3/meta.yaml
@@ -1,0 +1,79 @@
+{% set version = "2.0.420" %}
+{% set sha256 = "0d28932e363e80b4519b04a512df899189c612a4c097130219d6e0ebbfde2a34" %}
+{% set io_lib_version = "1.14.9" %}
+
+package:
+  name: libmaus2-pkg
+  version: "{{ version }}"
+
+about:
+  home: https://github.com/gt1/libmaus2
+  license: Various
+  summary: Collection of data structures and algorithms.
+
+build:
+  number: 3
+
+source:
+  url: https://github.com/gt1/libmaus2/archive/{{ version }}-release-20171116172420.tar.gz
+  fn: libmaus2-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+requirements:
+  build:
+    - {{ compiler("cxx") }}
+    - make
+    - pkg-config
+  host:
+    - irods-dev
+    - libgnutls-dev
+    - libnettle-dev
+    - libstaden-read-dev =={{ io_lib_version }}
+    - libz-dev
+  run:
+    - libgnutls
+    - libnettle
+    - libstaden-read =={{ io_lib_version }}
+    - libz
+    - snappy
+
+outputs:
+  - name: libmaus2
+    version: {{ version }}
+    requirements:
+      build:
+        - {{ compiler("cxx") }}
+        - make
+        - pkg-config
+      host:
+        - irods-dev
+        - libgnutls-dev
+        - libnettle-dev
+        - libstaden-read-dev =={{ io_lib_version }}
+        - libz-dev
+      run:
+        - libgnutls
+        - libnettle
+        - libstaden-read =={{ io_lib_version }}
+        - libz
+        - snappy
+    files:
+      - lib/libmaus*.*
+      - lib/libmaus2/{{ version }}/*.so
+    test:
+      commands:
+        - test -f ${PREFIX}/lib/libmaus2.a
+        - test -h ${PREFIX}/lib/libmaus2.so
+
+  - name: libmaus2-dev
+    version: {{ version }}
+    requirements:
+      run:
+        - {{ pin_subpackage("libmaus2", exact=True) }}
+    files:
+      - include/libmaus2
+      - lib/pkgconfig/libmaus2*.pc
+    test:
+      commands:
+        - test -f ${PREFIX}/include/libmaus2/LibMausConfig.hpp
+

--- a/recipes/libpam/1.3.1/build.sh
+++ b/recipes/libpam/1.3.1/build.sh
@@ -1,0 +1,11 @@
+umask 022
+touch ChangeLog
+autoreconf -fiv
+
+./configure --prefix=$PREFIX
+cd libpam
+make
+make install
+mkdir $PREFIX/include/security
+mv $PREFIX/include/*pam* $PREFIX/include/security
+cd ..

--- a/recipes/libpam/1.3.1/meta.yaml
+++ b/recipes/libpam/1.3.1/meta.yaml
@@ -1,0 +1,42 @@
+{% set version = "1.3.1" %}
+{% set git_rev = "v1.3.1" %}
+
+package:
+  name: libpam
+  version: "{{ version }}"
+
+about:
+  home: http://www.linux-pam.org/
+  license: MIT
+  summary: Linux PAM (Pluggable Authentication Modules for Linux) project
+
+source:
+  git_url: https://github.com/linux-pam/linux-pam.git
+  git_rev: {{ git_rev }}
+
+requirements:
+  build:
+    - {{ compiler("c") }}
+    - autoconf
+    - automake>=1.16.2
+    - make
+    - m4
+    - libtool
+    - pkg-config
+  host:
+    - gettext
+
+outputs:
+  - name: libpam
+    files:
+      - lib/libpam.so
+      - lib/libpam.so.0
+      - lib/libpam.so.0.84.2
+      - lib/libpam.la
+      - include/security/_pam_compat.h
+      - include/security/_pam_macros.h
+      - include/security/_pam_types.h
+      - include/security/pam_appl.h
+      - include/security/pam_ext.h
+      - include/security/pam_modules.h
+      - include/security/pam_modutil.h

--- a/recipes/tears/1.3.1/build.sh
+++ b/recipes/tears/1.3.1/build.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -ex
+
+autoreconf -fi
+
+export LD_LIBRARY_PATH="$PREFIX/lib"
+
+CPPFLAGS="-I$PREFIX/include -I$PREFIX/include/irods" \
+ LDFLAGS="-L$PREFIX/lib -L$PREFIX/lib/irods/externals" \
+              ./configure --prefix="$PREFIX" --with-irods="$PREFIX"
+
+make  CPPFLAGS="-I$PREFIX/include" LDFLAGS="-L$PREFIX/lib"
+make install prefix="$PREFIX"

--- a/recipes/tears/1.3.1/meta.yaml
+++ b/recipes/tears/1.3.1/meta.yaml
@@ -1,0 +1,38 @@
+{% set version = "1.3.1" %}
+
+package:
+  name: tears
+  version: "{{ version }}"
+
+about:
+  home: https://github.com/whitwham/tears
+  license: GPL3
+  summary:  Stream files to and from iRODS.
+
+build:
+  number: 0
+
+source:
+  git_url: https://github.com/whitwham/tears.git
+  git_rev: "v{{ version }}"
+
+requirements:
+  build:
+    - {{ compiler("c") }}
+    - autoconf
+    - automake>=1.16.2
+    - make
+    - perl
+  host:
+    - irods-dev ==4.2.7
+    - libjansson-dev
+    - libssl
+    - libssl-dev
+  run:
+    - irods-runtime ==4.2.7
+    - libjansson
+    - libssl
+
+test:
+  commands:
+    - test -x ${PREFIX}/bin/tears


### PR DESCRIPTION
avrocpp is included owing to dependency issues with the current version on conda-forge. Unit tests for that package are disabled as they don't work (fortunately I do not believe avrocpp is used client side anyway).
IRODS currently completes building but has plenty of warnings, many of which can be eliminated by some tweaks to the package that I'll make later. We should probably also stop packaging libz now there is a conda-forge version of the same package version available.