### PR TITLE
Create bin directory on npg_qc_utils install

### DIFF
--- a/recipes/npg_qc_utils/65.0/build.sh
+++ b/recipes/npg_qc_utils/65.0/build.sh
@@ -4,6 +4,8 @@ set -ex
 
 n="$CPU_COUNT"
 
+mkdir -p "$PREFIX/bin/"
+
 pushd fastq_summ
 mkdir -p build
 make -j $n CC="$GCC" \
@@ -35,6 +37,6 @@ mkdir -p build
 make -j $n  CC="$GCC" \
      CPPFLAGS="-I$PREFIX/include" \
      LDFLAGS="-L$PREFIX/lib"
-make install installdir="$PREFIX/bin"
+make install installdir="$PREFIX/bin/"
 popd
 

--- a/recipes/npg_qc_utils/67.0/build.sh
+++ b/recipes/npg_qc_utils/67.0/build.sh
@@ -4,6 +4,8 @@ set -ex
 
 n="$CPU_COUNT"
 
+mkdir -p "$PREFIX/bin/"
+
 pushd norm_fit
 mkdir -p build
 make -j $n CC="$GCC" \
@@ -16,5 +18,5 @@ mkdir -p build
 make -j $n  CC="$GCC" \
      CPPFLAGS="-I$PREFIX/include" \
      LDFLAGS="-L$PREFIX/lib"
-make install installdir="$PREFIX/bin"
+make install installdir="$PREFIX/bin/"
 popd


### PR DESCRIPTION
The builds fail because they try to install to the bin directory, without creating it first.

Resolves #176, #184