### PR TITLE
Create bin directory on bam_stats install

### DIFF
--- a/recipes/bam_stats/1.13.0/build.sh
+++ b/recipes/bam_stats/1.13.0/build.sh
@@ -8,4 +8,5 @@ make ../bin/bam_stats CC="$GCC" \
      CPPFLAGS="-I$PREFIX/include" \
      LDFLAGS="-L$PREFIX/lib"
 
+mkdir -p "$PREFIX/bin/"
 cp ../bin/bam_stats "$PREFIX/bin/"

--- a/recipes/bam_stats/4.4.1/build.sh
+++ b/recipes/bam_stats/4.4.1/build.sh
@@ -8,4 +8,5 @@ make ../bin/bam_stats CC="$GCC" \
      CPPFLAGS="-I$PREFIX/include" \
      LDFLAGS="-L$PREFIX/lib"
 
+mkdir -p "$PREFIX/bin/"
 cp ../bin/bam_stats "$PREFIX/bin/"


### PR DESCRIPTION
The builds fail because they try to install to the bin directory, without creating it first.

Resolves #180, #181