### PR TITLE
Enable a clean iRODS build with fewer dependencies

### DIFF
--- a/red-recipes/irods/4.2.7/build.sh
+++ b/red-recipes/irods/4.2.7/build.sh
@@ -12,17 +12,6 @@ untar_data() {
     fi
 }
 
-unrpm_data() {
-    local rpm="$1"
-    mkdir -p ./tmp
-    pushd tmp
-    rpm2cpio ../"$rpm" | cpio --extract --make-directories
-    popd
-    tar cf - -C ./tmp . | tar xv --strip-components=2 --directory="$PREFIX" \
-                              --exclude='*.o' --exclude-backups
-    rm -r ./tmp
-}
-
 running_in_docker() {
     if [ -f /.dockerenv ]; then
         return 0
@@ -31,109 +20,78 @@ running_in_docker() {
     fi
 }
 
-install_gcc_ubuntu() {
-    GCC_VERSION=
-    grep precise /etc/lsb-release && GCC_VERSION="4.6"
-    grep xenial  /etc/lsb-release && GCC_VERSION="4.8"
-    grep bionic  /etc/lsb-release && GCC_VERSION="4.8"
-
-    sudo apt-get install -y "g++-$GCC_VERSION" "gcc-$GCC_VERSION"
-
-    sudo update-alternatives --install /usr/bin/gcc gcc "/usr/bin/gcc-$GCC_VERSION" 100
-    sudo update-alternatives --install /usr/bin/g++ g++ "/usr/bin/g++-$GCC_VERSION" 100
-    sudo update-alternatives --set gcc "/usr/bin/gcc-$GCC_VERSION"
-    sudo update-alternatives --set g++ "/usr/bin/g++-$GCC_VERSION"
-}
-
-install_deps_ubuntu() {
-    sudo apt-get install -y autoconf automake help2man make \
-         libtool pkg-config texinfo
-
-    sudo apt-get install -y libjson-perl python-dev
-
-    sudo apt-get install -y libbz2-dev libcurl4-gnutls-dev \
-         libfuse-dev libkrb5-dev libmysqlclient-dev libpam0g-dev \
-         libssl-dev unixodbc-dev libxml2-dev zlib1g-dev
-}
-
-# Requires:
-#
-# sudo subscription-manager register --org="..." --activationkey="..."
-# sudo subscription-manager repos --enable rhel-7-server-extras-rpms
-# sudo subscription-manager repos --enable rhel-7-server-supplementary-rpms
-# sudo subscription-manager repos --enable rhel-7-server-optional-rpms
-
-install_gcc_rhel() {
-    sudo yum install -y gcc-c++
-}
-
-install_deps_rhel() {
-    sudo yum install -y help2man make rpm-build
-
-    sudo yum install -y perl-JSON python-devel
-
-    sudo yum install -y bzip2-devel curl-devel \
-         fuse-devel krb5-devel pam-devel \
-         openssl-devel unixODBC-devel libxml2-devel zlib-devel
-}
-
 export TERM=dumb
 
-if [ -f /etc/lsb-release ]; then
-    if running_in_docker ; then
-        echo "Running in Docker ... skipping package installation"
-#    else
-        #install_gcc_ubuntu
-        #install_deps_ubuntu
-    fi
-
-    export CFLAGs="-I$PREFIX/include"
-    export CCFLAGS="-I$PREFIX/include -Wno-deprecated-declarations"
-    export CXXFLAGS="-I$PREFIX/include -Wno-deprecated-declarations"
-    export LDFLAGS="-L$PREFIX/lib"
-    mkdir build_irods
-    mkdir build_icommands
-    cd build_irods
-
-    git submodule init && git submodule update
-    cmake -D CMAKE_CXX_FLAGS='-Wno-deprecated-declarations' -D CMAKE_LD_FLAGS='-Wno-deprecated-declarations' -D CMAKE_INSTALL_PREFIX=${PREFIX} -D IRODS_EXTERNALS_FULLPATH_CLANG=${BUILD_PREFIX} -D IRODS_EXTERNALS_FULLPATH_CPPZMQ=${PREFIX} -D IRODS_EXTERNALS_FULLPATH_ARCHIVE=${PREFIX} -D IRODS_EXTERNALS_FULLPATH_AVRO=${PREFIX} -D IRODS_EXTERNALS_FULLPATH_BOOST=${PREFIX} -D IRODS_EXTERNALS_FULLPATH_CLANG_RUNTIME=${PREFIX} -D IRODS_EXTERNALS_FULLPATH_ZMQ=${PREFIX} -D IRODS_EXTERNALS_FULLPATH_JANSSON=${PREFIX} -D CMAKE_C_FLAGS="-I$PREFIX/include" -D CMAKE_EXE_LINKER_FLAGS="-Wl,-rpath-link,${PREFIX}/lib -fuse-ld=$LD" \
-	   -D IRODS_LINUX_DISTRIBUTION_NAME='Ubuntu' -D IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR='12' -D IRODS_LINUX_DISTRIBUTION_VERSION_CODENAME='Precise' -D IRODS_EXTERNALS_FULLPATH_CATCH2=${PREFIX} -DCMAKE_AR=$AR -DCMAKE_LINKER=$LD -DCMAKE_SYSROOT=${PREFIX} -D TOOL_PREFIX=${HOST}- ../irods
-    make -j${CPU_COUNT} package
-    #for the icommands
-    cd ..
-    mkdir build
-    cd build
-    ${AR} vx ../build_irods/irods-dev_4.2.7~Precise_amd64.deb
-    untar_data
-    ${AR} vx ../build_irods/irods-runtime_4.2.7~Precise_amd64.deb
-    untar_data
-    cd ../build_icommands
-    cmake -D CMAKE_CXX_FLAGS='-Wno-deprecated-declarations' -D CMAKE_LD_FLAGS='-Wno-deprecated-declarations' -D CMAKE_INSTALL_PREFIX=${PREFIX} -D IRODS_DIR=$PREFIX/lib/irods/cmake -D CMAKE_EXE_LINKER_FLAGS="-Wl,-rpath-link,${PREFIX}/lib" -D IRODS_LINUX_DISTRIBUTION_NAME='Ubuntu' -D IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR='12' -D IRODS_LINUX_DISTRIBUTION_VERSION_CODENAME='Precise' -DCMAKE_AR=$AR -DCMAKE_LINKER=$LD -D CMAKE_EXE_LINKER_FLAGS="-Wl,-rpath-link,${PREFIX}/lib -fuse-ld=$LD" -DCMAKE_SYSROOT=${PREFIX} ../irods_client_icommands
-    make -j${CPU_COUNT} package
-    cd ../build
-    ${AR} vx ../build_icommands/irods-icommands_4.2.7~Precise_amd64.deb
-    untar_data
-
+if running_in_docker ; then
+    echo "Running in Docker ... "
 fi
 
-if [ -f /etc/redhat-release ]; then
-    if running_in_docker ; then
-        echo "Running in Docker ... skipping package installation"
-    else
-        install_gcc_rhel
-        install_deps_rhel
-    fi
+pushd irods
+git submodule init && git submodule update
+popd
 
-    export CCFLAGS="$PREFIX/include"
-    export LDRFLAGS="$PREFIX/lib"
-    ./packaging/build.sh --verbose icat postgres
-    ./packaging/build.sh --verbose icommands
+mkdir build_irods
+pushd build_irods
+cmake \
+    -D CMAKE_INSTALL_PREFIX=${PREFIX} \
+    -D IRODS_EXTERNALS_FULLPATH_CLANG=${BUILD_PREFIX} \
+    -D IRODS_EXTERNALS_FULLPATH_CPPZMQ=${PREFIX} \
+    -D IRODS_EXTERNALS_FULLPATH_ARCHIVE=${PREFIX} \
+    -D IRODS_EXTERNALS_FULLPATH_AVRO=${PREFIX} \
+    -D IRODS_EXTERNALS_FULLPATH_BOOST=${PREFIX} \
+    -D IRODS_EXTERNALS_FULLPATH_CLANG_RUNTIME=${PREFIX} \
+    -D IRODS_EXTERNALS_FULLPATH_ZMQ=${PREFIX} \
+    -D IRODS_EXTERNALS_FULLPATH_JANSSON=${PREFIX} \
+    -D IRODS_LINUX_DISTRIBUTION_NAME='Ubuntu' \
+    -D IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR='12' \
+    -D IRODS_LINUX_DISTRIBUTION_VERSION_CODENAME='Precise' \
+    -D IRODS_EXTERNALS_FULLPATH_CATCH2=${PREFIX} \
+    -D CMAKE_C_FLAGS="-I${PREFIX}/include" \
+    -D CMAKE_CXX_FLAGS='-Wno-deprecated-declarations' \
+    -D CMAKE_LD_FLAGS='-Wno-deprecated-declarations' \
+    -D CMAKE_EXE_LINKER_FLAGS="-Wl,-rpath-link,${PREFIX}/lib -fuse-ld=${LD}" \
+    -D CMAKE_C_COMPILER="${BUILD_PREFIX}/bin/clang" \
+    -D CMAKE_CXX_COMPILER="${BUILD_PREFIX}/bin/clang++" \
+    -D CMAKE_AR=${AR} \
+    -D CMAKE_LINKER=${LD} \
+    -D TOOL_PREFIX="${HOST}-" \
+    ../irods
+make VERBOSE=1 -j "$CPU_COUNT" package
+popd
 
-    cd build
+mkdir unpack
+pushd unpack
+${AR} vx ../build_irods/irods-dev_4.2.7~Precise_amd64.deb
+untar_data
 
-    unrpm_data irods-icommands-4.1.12-64bit-centos[0-9].rpm
-    unrpm_data irods-dev-4.1.12-64bit-centos[0-9].rpm
-fi
+${AR} vx ../build_irods/irods-runtime_4.2.7~Precise_amd64.deb
+untar_data
+popd
+
+mkdir build_icommands
+pushd build_icommands
+cmake \
+    -D CMAKE_INSTALL_PREFIX=${PREFIX} \
+    -D IRODS_LINUX_DISTRIBUTION_NAME='Ubuntu' \
+    -D IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR='12' \
+    -D IRODS_LINUX_DISTRIBUTION_VERSION_CODENAME='Precise' \
+    -D IRODS_DIR="${PREFIX}/lib/irods/cmake" \
+    -D CMAKE_CXX_FLAGS='-Wno-deprecated-declarations' \
+    -D CMAKE_LD_FLAGS='-Wno-deprecated-declarations' \
+    -D CMAKE_EXE_LINKER_FLAGS="-Wl,-rpath-link,${PREFIX}/lib -fuse-ld=${LD}" \
+    -D CMAKE_C_COMPILER="${BUILD_PREFIX}/bin/clang" \
+    -D CMAKE_CXX_COMPILER="${BUILD_PREFIX}/bin/clang++" \
+    -D CMAKE_AR=${AR} \
+    -D CMAKE_LINKER=${LD} \
+    -D TOOL_PREFIX="${HOST}-" \
+    ../irods_client_icommands
+make VERBOSE=1 -j "$CPU_COUNT" package
+popd
+
+pushd unpack
+${AR} vx ../build_icommands/irods-icommands_4.2.7~Precise_amd64.deb
+untar_data
+popd
 
 # Fix all the absolute symlinks pointing to /usr/include
 perl -le 'use strict; use File::Basename; foreach (@ARGV) { if (my $f = readlink $_) { if ($f =~ m{^/usr/}sm) { unlink $_; symlink(basename($f), $_) } } }' $PREFIX/include/irods/*.hpp

--- a/red-recipes/irods/4.2.7/meta.yaml
+++ b/red-recipes/irods/4.2.7/meta.yaml
@@ -1,4 +1,5 @@
 {% set version = "4.2.7" %}
+{% set clang_version = "8.0.1" %}
 
 package:
   name: irods
@@ -10,7 +11,7 @@ about:
   summary: "Open Source Data Management Software."
 
 build:
-  number: 8
+  number: 9
 
 source:
   - git_url: https://github.com/irods/irods.git
@@ -26,60 +27,46 @@ source:
 
 requirements:
   build:
-    - cmake>=3.5.0
+    - cmake >=3.5.0
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - clang==8.0.1
-    - clangxx==8.0.1
+    - clang =={{ clang_version }}
+    - clangxx =={{ clang_version }}
     - make
-    - gzip
     - help2man
   host:
-    - libssl-dev
-    - cppzmq
-    - libarchive
-    - avrocpp
-    - boost-cpp>=1.73.0
-    - zeromq
-    - libpam
-    - unixodbc
-    - libjansson-dev
+    - avrocpp-dev
+    - libboost-dev
     - catch2
-    - krb5
-    - pthread-stubs
-  run:
-    - libssl
     - cppzmq
-    - libarchive
-    - avrocpp
-    - boost-cpp>=1.73.0
-    - zeromq
     - krb5
+    - libarchive
+    - libjansson-dev
+    - libpam-dev
+    - libssl-dev
+    - pthread-stubs
+    - unixodbc
+    - zeromq
 
 outputs:
   - name: irods-runtime
     version: {{ version }}
     requirements:
-      host:
-        - libssl-dev
       run:
+        - libavrocpp
+        - libboost
+#       - krb5  # Avoids pulling in zlib from defaults
         - libarchive
-        - libssl
-        - boost-cpp>=1.73.0
-        - avrocpp
         - libjansson
+        - libpam
+        - libssl
         - zeromq
-        - krb5
     files:
       - lib/irods/plugins
-      - lib/libirods_client.so
-      - lib/libirods_client.so.4.2.7
-      - lib/libirods_common.so
-      - lib/libirods_common.so.4.2.7
-      - lib/libirods_plugin_dependencies.so
-      - lib/libirods_plugin_dependencies.so.4.2.7
-      - lib/libirods_server.so
-      - lib/libirods_server.so.4.2.7
+      - lib/libirods_client.so*
+      - lib/libirods_common.so*
+      - lib/libirods_plugin_dependencies.so*
+      - lib/libirods_server.so*
 
   - name: irods-dev
     version: {{ version }}
@@ -89,12 +76,12 @@ outputs:
     files:
       - include/irods
       - lib/irods/externals
+      - lib/libRodsAPIs.a
+      - lib/libirods_client.a
       - lib/libirods_client_api.a
-      - lib/libirods_client_plugins.a
       - lib/libirods_client_api_table.a
       - lib/libirods_client_core.a
-      - lib/libirods_client.a
-      - lib/libRodsAPIs.a
+      - lib/libirods_client_plugins.a
       - lib/libirods_server.a
       - share/irods
 
@@ -103,11 +90,6 @@ outputs:
     requirements:
       run:
         - {{ pin_subpackage("irods-runtime", exact=True) }}
-        - libssl
-        - boost-cpp>=1.73.0
-        - avrocpp
-        - libjansson
-        - zeromq
     files:
       - bin/iadmin
       - bin/ibun
@@ -155,6 +137,7 @@ outputs:
       - bin/iuserinfo
       - bin/ixmsg
       - bin/izonereport
+      - share/man
 
     test:
       commands:


### PR DESCRIPTION
Add a dependency on our avrocpp build (built with boost 1.73.0 support
to remove other dependencies).

Add a dependency on our boost 1.73.0 build (built without Python
support to remove other dependencies). Remove the boost-cpp
(conda-forge) dependency.

Remove the krb runtime dependency to avoid conflicts (we don't support
Kerberos clients).

Remove the gzip build dependency (not needed).

Lint and sort the build recipe for maintenance.

Fix git submodule init for iRODS to be done in the correct directory.

Lint and organise the build script for maintenance/clarity.

Remove legacy functions from build.sh