### PR TITLE
Zlib download url fix

### DIFF
--- a/recipes/zlib/1.2.11/meta.yaml
+++ b/recipes/zlib/1.2.11/meta.yaml
@@ -14,7 +14,7 @@ build:
   number: 2
 
 source:
-  url: https://sourceforge.mirrorservice.org/l/li/libpng/zlib/{{ version }}/zlib-{{ version }}.tar.gz
+  url: https://sourceforge.net/projects/libpng/files/zlib/{{ version }}/zlib-{{ version }}.tar.gz/download
   fn: zlib-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 


### PR DESCRIPTION
Amend zlib download as previous one no longer works.
Leave build number the same as checksums are unchanged.