### PR TITLE
Switch use of ancestor and descendant in recipebook files

### DIFF
--- a/tools/bin/recipebook
+++ b/tools/bin/recipebook
@@ -104,9 +104,9 @@ def main():
         nv = (args.package, parse(args.version))
         if nv in recipe_book.dependency_graph():
             if args.provides:
-                recipe_book.print_ancestors(nv)
-            else:
                 recipe_book.print_descendants(nv)
+            else:
+                recipe_book.print_ancestors(nv)
         else:
             raise ValueError("Package {} version {} is not present "
                              "in the graph".format(nv[0], nv[1]))

--- a/tools/recipebook/recipebook.py
+++ b/tools/recipebook/recipebook.py
@@ -248,7 +248,7 @@ class RecipeBook(object):
         """
         return self.pkg_parent[name]
 
-    def package_ancestors(self, nv: Tuple[str, Version]) -> nx.DiGraph:
+    def package_descendants(self, nv: Tuple[str, Version]) -> nx.DiGraph:
         """Returns a graph of all the packages that depend on the named
         package version.
 
@@ -261,7 +261,7 @@ class RecipeBook(object):
         g = self.dependency_graph()
         return nx.subgraph(g, nx.descendants(g, nv))
 
-    def package_descendants(self, nv: Tuple[str, Version]) -> nx.DiGraph:
+    def package_ancestors(self, nv: Tuple[str, Version]) -> nx.DiGraph:
         """Returns a graph of all the packages on which the named package
          version depends.
 
@@ -280,23 +280,23 @@ class RecipeBook(object):
         """
         self.__print_subgraph(self.dependency_graph())
 
-    def print_ancestors(self, nv: Tuple[str, Version]):
+    def print_descendants(self, nv: Tuple[str, Version]):
         """Prints a sub-graph of packages that depend on the named package
         version.
 
         Args:
             nv: package name, version tuple
         """
-        self.__print_subgraph(self.package_ancestors(nv))
+        self.__print_subgraph(self.package_descendants(nv))
 
-    def print_descendants(self, nv: Tuple[str, Version]):
+    def print_ancestors(self, nv: Tuple[str, Version]):
         """Prints a sub-graph of packages on which the named package version
         depends.
 
         Args:
         nv: package name, version tuple
         """
-        self.__print_subgraph(self.package_descendants(nv))
+        self.__print_subgraph(self.package_ancestors(nv))
 
     def print_package(self, nv: Tuple[str, Version]):
         if self.__is_root_node(nv):


### PR DESCRIPTION
Ancestor means a package on which the current package depends
Descendant means a package which depends on the current package