### PR TITLE
Optionally require arguments when other arguments are present for recipebook

### DIFF
--- a/tools/bin/recipebook
+++ b/tools/bin/recipebook
@@ -104,9 +104,9 @@ def main():
         nv = (args.package, parse(args.version))
         if nv in recipe_book.dependency_graph():
             if args.provides:
-                recipe_book.print_ancestors(nv)
-            else:
                 recipe_book.print_descendants(nv)
+            else:
+                recipe_book.print_ancestors(nv)
         else:
             raise ValueError("Package {} version {} is not present "
                              "in the graph".format(nv[0], nv[1]))

--- a/tools/bin/recipebook
+++ b/tools/bin/recipebook
@@ -56,15 +56,21 @@ parser.add_argument("recipes",
                     type=str, nargs="?", default=".")
 
 parser.add_argument("-p", "--package", type=str,
+                    required=any(arg in sys.argv for arg in
+                                 ["--provides", "-v", "--version"]),
                     help="Report dependency relationships for the "
                          "specified package. Defaults to reporting the "
                          "packages that the specified package depends on. "
-                         "See --provides")
+                         "See --provides."
+                         "Required by --provides and -v/--version.")
 parser.add_argument("-v", "--version", type=str,
+                    required=any(arg in sys.argv for arg in
+                                 ["--provides", "-p", "--package"]),
                     help="Report dependency relationships of the "
                          "specified package version. Defaults to reporting "
                          "the packages that the specified package depends on. "
-                         "See --provides")
+                         "See --provides."
+                         "Required by --provides and -p/--package.")
 parser.add_argument("-c", "--changes", type=str,
                     help="Report only on recipes that have changed "
                          "relative to another branch (defaults to 'master'")
@@ -73,7 +79,8 @@ parser.add_argument("--provides",
                          "-p|--package and -v|--version, report the packages "
                          "which the specified package provides for. "
                          "i.e. those that are dependencies of the package, "
-                         "rather than those it depends on",
+                         "rather than those it depends on."
+                         "Requires -p/--package and -v/--version.",
                     action="store_true")
 
 parser.add_argument("--debug",

--- a/tools/recipebook/recipebook.py
+++ b/tools/recipebook/recipebook.py
@@ -248,7 +248,7 @@ class RecipeBook(object):
         """
         return self.pkg_parent[name]
 
-    def package_ancestors(self, nv: Tuple[str, Version]) -> nx.DiGraph:
+    def package_descendants(self, nv: Tuple[str, Version]) -> nx.DiGraph:
         """Returns a graph of all the packages that depend on the named
         package version.
 
@@ -261,7 +261,7 @@ class RecipeBook(object):
         g = self.dependency_graph()
         return nx.subgraph(g, nx.descendants(g, nv))
 
-    def package_descendants(self, nv: Tuple[str, Version]) -> nx.DiGraph:
+    def package_ancestors(self, nv: Tuple[str, Version]) -> nx.DiGraph:
         """Returns a graph of all the packages on which the named package
          version depends.
 
@@ -280,23 +280,23 @@ class RecipeBook(object):
         """
         self.__print_subgraph(self.dependency_graph())
 
-    def print_ancestors(self, nv: Tuple[str, Version]):
+    def print_descendants(self, nv: Tuple[str, Version]):
         """Prints a sub-graph of packages that depend on the named package
         version.
 
         Args:
             nv: package name, version tuple
         """
-        self.__print_subgraph(self.package_ancestors(nv))
+        self.__print_subgraph(self.package_descendants(nv))
 
-    def print_descendants(self, nv: Tuple[str, Version]):
+    def print_ancestors(self, nv: Tuple[str, Version]):
         """Prints a sub-graph of packages on which the named package version
         depends.
 
         Args:
         nv: package name, version tuple
         """
-        self.__print_subgraph(self.package_descendants(nv))
+        self.__print_subgraph(self.package_ancestors(nv))
 
     def print_package(self, nv: Tuple[str, Version]):
         if self.__is_root_node(nv):


### PR DESCRIPTION
--version and --package require each other, and are both required by --provides.
(based on switch_ancestry branch)