### PR TITLE
Use the correct build channel syntax for recipebook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,18 @@
 
-dist: xenial
+dist: bionic
 language: python
-python: 3.7
+python: 3.8
 
 services: docker
 
 env:
   - >
-    IRODS_IMAGE=wsinpg/ub-12.04-conda-irods-4.1:0.9
-    CONDA_IMAGE=wsinpg/ub-12.04-conda:0.9
+    CONDA_IMAGE=wsinpg/ub-12.04-conda:1.1
     CONDA_CHANNEL=https://dnap.cog.sanger.ac.uk/npg/conda/devel/generic
     COMPARE_BRANCH=origin/devel
 
 before_install:
   - docker --version
-  # We should rarely need to pull the iRODS build image, so we don't
-  # do it preemptively here
   - docker pull $CONDA_IMAGE
 
 install:
@@ -32,7 +29,6 @@ script:
     ./tools/bin/recipebook --changes $COMPARE_BRANCH recipes | ./tools/bin/build
     --recipes-dir $TRAVIS_BUILD_DIR
     --artefacts-dir $TRAVIS_BUILD_DIR/conda-artefacts
-    --irods-build-image $IRODS_IMAGE
     --conda-build-image $CONDA_IMAGE
     --build-channel $CONDA_CHANNEL
     --verbose
@@ -40,11 +36,8 @@ script:
     ./tools/bin/recipebook --changes $COMPARE_BRANCH red-recipes | ./tools/bin/build
     --recipes-dir $TRAVIS_BUILD_DIR
     --artefacts-dir $TRAVIS_BUILD_DIR/conda-artefacts
-    --irods-build-image $IRODS_IMAGE
     --conda-build-image $CONDA_IMAGE
-    --build-channel $CONDA_CHANNEL
-    --build-channel conda-forge
-    --build-channel bioconda
+    --build-channel $CONDA_CHANNEL conda-forge bioconda
     --verbose
   - kill %1
   - ls -l $TRAVIS_BUILD_DIR/conda-artefacts/linux-64

--- a/tools/bin/build
+++ b/tools/bin/build
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2019, 2020 Genome Research Ltd. All rights reserved.
+# Copyright © 2019, 2020, 2021 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -36,7 +36,6 @@ DEFAULT_RECIPES_MOUNT="/home/conda/recipes"
 DEFAULT_ARTEFACTS_DIR=os.path.expandvars("$HOME/conda-artefacts")
 DEFAULT_ARTEFACTS_MOUNT="/opt/conda/conda-bld"
 
-IRODS_BUILD_IMAGE="wsinpg/ub-12.04-conda-irods-4.1:latest"
 DEFAULT_BUILD_IMAGE="wsinpg/ub-12.04-conda:latest"
 
 description = """
@@ -80,10 +79,6 @@ parser.add_argument("--build-channel","--build-channels",
                     "defaults to no extra channels",
                     type=str, nargs="*", default=[])
 
-parser.add_argument("--irods-build-image",
-                    help="The Docker image used to build iRODS 4.1, "
-                    "defaults to {}".format(IRODS_BUILD_IMAGE),
-                    type=str, nargs="?", default=IRODS_BUILD_IMAGE)
 parser.add_argument("--conda-build-image",
                     help="Docker image used to build packages, "
                     "defaults to {}".format(DEFAULT_BUILD_IMAGE),
@@ -126,16 +121,11 @@ docker_pull(args.conda_build_image)
 fail = False
 
 for line in sys.stdin.readlines():
-    line.rstrip();
+    line.rstrip()
     name, version, path = line.split()
     log.info("Working on %s %s %s", name, version, path)
 
     build_image = args.conda_build_image
-    if name == "irods" and version[:4]=="4.1.":
-        build_image = args.irods_build_image
-        log.info("Using image %s", build_image)
-        docker_pull(args.irods_build_image)
-
     build_script = \
         'export CONDA_BLD_PATH="{}" ; '.format(args.artefacts_mount)
     build_script += \


### PR DESCRIPTION
Update Conda build image to ub-12.04-conda:1.1.

Update Travis VM to bionic.

Update Python to 3.8.

Remove reference to IRODS_IMAGE as we no longer use a special Docker
image to build iRODS.