### PR TITLE
Add iRODS 4.2.8

### DIFF
--- a/recipes/avrocpp/1.9.0/build.sh
+++ b/recipes/avrocpp/1.9.0/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+mkdir build
+cd build
+
+export CXXFLAGS="-I$PREFIX/include -fPIC"
+export LDFLAGS="-L$BUILD_PREFIX/lib -lrt"
+
+cmake .. \
+      -D CMAKE_INSTALL_PREFIX="$PREFIX" \
+      -D BOOST_ROOT="$PREFIX" \
+      -D SNAPPY_ROOT_DIR="$PREFIX" \
+      -D CMAKE_BUILD_TYPE="RelWithDebInfo" \
+      -D CMAKE_AR="$AR"
+
+make -j "$CPU_COUNT" VERBOSE=1 CXX_FLAGS="$CXXFLAGS"
+make install

--- a/recipes/avrocpp/1.9.0/meta.yaml
+++ b/recipes/avrocpp/1.9.0/meta.yaml
@@ -1,0 +1,74 @@
+{% set version = "1.9.0" %}
+{% set hash = "14ad1114cfac67007e784dff706b03f58d145148" %}
+{% set boost_version = "1.73.0" %}
+
+package:
+  name: avrocpp
+  version: {{ version }}
+
+source:
+  fn: avro-cpp-{{ version }}.tar.gz
+  url: https://archive.apache.org/dist/avro/avro-{{ version }}/cpp/avro-cpp-{{ version }}.tar.gz
+  sha1: {{ hash }}
+
+build:
+  number: 2
+
+requirements:
+  build:
+    - cmake
+    - make
+    - pkg-config
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - libboost-dev>={{ boost_version }}
+    - liblzma-dev
+    - libz-dev
+    - snappy
+  run:
+    - libboost
+    - liblzma
+    - libz
+    - snappy
+
+outputs:
+  - name: libavrocpp
+    version: {{ version }}
+    requirements:
+      run:
+        - libboost >={{ boost_version }}
+        - liblzma
+        - libz
+        - snappy
+    files:
+      - lib/libavrocpp.so*
+    test:
+      commands:
+        - test -f ${PREFIX}/lib/libavrocpp.so
+        - conda inspect linkages libavrocpp
+
+  - name: avrocpp-dev
+    version: {{ version }}
+    requirements:
+      run:
+        - {{ pin_subpackage("libavrocpp", exact=True) }}
+    files:
+      - bin/avrogencpp
+      - include/avro
+      - lib/libavrocpp_s.a
+    test:
+      commands:
+        - test -f ${PREFIX}/lib/libavrocpp_s.a
+
+about:
+  home: http://hadoop.apache.org/avro
+  license: Apache 2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: 'Avro is a serialization and RPC framework.'
+
+extra:
+  recipe-maintainers:
+    - wtsi-npg
+    - mariusvniekerk

--- a/recipes/boost/1.73.0/conda_build_config.yaml
+++ b/recipes/boost/1.73.0/conda_build_config.yaml
@@ -1,0 +1,9 @@
+CFLAGS: >-
+  -O2
+  -fPIC
+  -ffunction-sections
+  -fstack-protector-strong
+  -ftree-vectorize
+  -march=x86-64
+  -mtune=generic
+  -pipe

--- a/recipes/json/3.9.1/build.sh
+++ b/recipes/json/3.9.1/build.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -ex
+
+n="$CPU_COUNT"
+
+rm -rf build
+mkdir build
+
+pushd build
+
+cmake -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DBUILD_TESTING=OFF \
+      ..
+
+make -j $n
+make install
+
+popd

--- a/recipes/json/3.9.1/meta.yaml
+++ b/recipes/json/3.9.1/meta.yaml
@@ -1,0 +1,34 @@
+{% set version = "3.9.1" %}
+{% set sha256 = "4cf0df69731494668bdd6460ed8cb269b68de9c19ad8c27abc24cd72605b2d5b" %}
+
+package:
+  name: json
+  version: "{{ version }}"
+
+about:
+  home: https://json.nlohmann.me/
+  license: MIT
+  summary: "JSON for Modern C++ is a C++11 JSON parser"
+
+source:
+  url: https://github.com/nlohmann/json/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cmake
+    - make
+
+files:
+  - include/nlohmann/
+  - lib/pkgconfig/nlohmann_json.pc
+  - lib/cmake/nlohmann_json/
+
+test:
+  commands:
+    - test -f ${PREFIX}/include/nlohmann/json.hpp

--- a/recipes/krb5/1.19.1/build.sh
+++ b/recipes/krb5/1.19.1/build.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -ex
+
+n="$CPU_COUNT"
+
+pushd src
+
+autoreconf -i
+./configure --prefix="$PREFIX" \
+	    --host=${HOST} \
+            --build=${BUILD} \
+	    --with-crypto-impl=openssl \
+	    --without-tcl \
+            --without-libedit \
+            --without-readline \
+            --without-system-verto
+
+make -j $n
+make install
+
+popd
+

--- a/recipes/krb5/1.19.1/meta.yaml
+++ b/recipes/krb5/1.19.1/meta.yaml
@@ -1,0 +1,81 @@
+{% set version = "1.19.1" %}
+{% set sha256 = "09d8135425e67242ad18bbda54843ba26aa0102893dfcfa0d0910cb496d7bf42" %}
+
+package:
+  name: krb5
+  version: {{ version }}
+
+about:
+  home: http://web.mit.edu/kerberos/
+  license: MIT
+  summary: "A network authentication protocol"
+
+source:
+  url: https://github.com/krb5/krb5/archive/krb5-{{ version }}-final.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - autoconf
+    - automake
+    - bison
+    - libtool
+    - make
+    - pkg-config
+  host:
+    - libssl-dev
+  run:
+    - libssl
+
+outputs:
+  - name: krb5
+    version: {{ version }}
+    requirements:
+      run:
+        - {{ pin_subpackage("libkrb5", exact=True) }}
+        - libssl
+    files:
+      - bin
+      - sbin
+      - share/man/man1
+      - share/locale
+    test:
+      command:
+        - kinit --help
+
+  - name: libkrb5
+    requirements:
+      run:
+        - libssl
+    files:
+      - lib/libk*
+    test:
+      commands:
+        - test -h ${PREFIX}/lib/libkrb5.so
+        - test -f $( readlink -f ${PREFIX}/lib/libkrb5.so )
+
+  - name: krb5-dev
+    version: {{ version }}
+    requirements:
+      run:
+        - {{ pin_subpackage("libkrb5", exact=True) }}
+        - libssl
+    files:
+      - include/com_err.h
+      - include/gssapi
+      - include/gssapi.h
+      - include/gssrpc
+      - include/kadm5
+      - include/kdb.h
+      - include/krad.h
+      - include/krb5
+      - include/krb5.h
+      - include/profile.h
+    test:
+      commands:
+        - test -f ${PREFIX}/include/krb5.h

--- a/recipes/libarchive/3.5.1/build.sh
+++ b/recipes/libarchive/3.5.1/build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -ex
+
+n="$CPU_COUNT"
+
+./configure --prefix="$PREFIX" \
+	    --without-iconv \
+	    --without-lz4 \
+	    --without-lzo2 \
+	    --without-zstd \
+	    --without-cng \
+	    --without-openssl \
+	    --without-nettle \
+	    --without-expat
+
+make -j $n
+make install

--- a/recipes/libarchive/3.5.1/meta.yaml
+++ b/recipes/libarchive/3.5.1/meta.yaml
@@ -1,0 +1,67 @@
+{% set version = "3.5.1" %}
+{% set sha256 = "9015d109ec00bb9ae1a384b172bf2fc1dff41e2c66e5a9eeddf933af9db37f5a" %}
+
+package:
+  name: libarchive-pkg
+  version: "{{ version }}"
+
+about:
+  home: https://www.libarchive.org/
+  license: BSD-2-Clause
+  summary: "Multi-format archive and compression library"
+
+source:
+  url: https://github.com/libarchive/libarchive/releases/download/{{ version }}/libarchive-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler("c") }}
+    - make
+    - pkg-config
+  host:
+    - libbz2-dev
+    - liblzma-dev
+    - libz-dev
+  run:
+    - libbz2
+    - liblzma
+    - libz
+
+outputs:
+  - name: libarchive
+    files:
+      - lib/libarchive.so*
+    test:
+      commands:
+        - test -h ${PREFIX}/lib/libarchive.so
+        - test -f $( readlink -f ${PREFIX}/lib/libarchive.so )
+
+  - name: libarchive-dev
+    files:
+      - include/archive.h
+      - include/archive_entry.h
+      - lib/libarchive.a
+      - lib/pkgconfig/libarchive.pc
+      - share/man/man3
+      - share/man/man5
+    requirements:
+      run:
+        - {{ pin_subpackage("libarchive", exact=True) }}
+    test:
+      commands:
+        - test -f ${PREFIX}/include/archive.h
+        - test -f ${PREFIX}/lib/libarchive.a
+
+  - name: libarchive-bin
+    files:
+      - bin/bsd*
+      - share/man/man1
+    test:
+      commands:
+        - test -f ${PREFIX}/bin/bsdcat
+        - test -f ${PREFIX}/bin/bsdcpio
+        - test -f ${PREFIX}/bin/bsdtar

--- a/recipes/nanodbc/2.13.0/build.sh
+++ b/recipes/nanodbc/2.13.0/build.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -ex
+
+n="$CPU_COUNT"
+
+mkdir build
+cd build
+
+export CXXFLAGS="-I$PREFIX/include"
+
+cmake -G "Unix Makefiles" \
+      -D CMAKE_INSTALL_PREFIX="$PREFIX" \
+      -D CMAKE_CXX_FLAGS='-std=c++14' \
+      -D NANODBC_ENABLE_UNICODE=OFF \
+      -D BUILD_SHARED_LIBS=ON \
+      -D NANODBC_DISABLE_LIBCXX=ON \
+      -D NANODBC_ODBC_VERSION=SQL_OV_ODBC3 \
+      -D NANODBC_DISABLE_EXAMPLES=ON \
+      -D NANODBC_DISABLE_TESTS=ON \
+      ..
+
+make VERBOSE=1 -j "$n"
+make install
+
+

--- a/recipes/nanodbc/2.13.0/meta.yaml
+++ b/recipes/nanodbc/2.13.0/meta.yaml
@@ -1,0 +1,34 @@
+{% set version = "2.13.0" %}
+{% set sha256 = "174080f1cab25b1d7fe5a8e2862f4e730a1c7c1732b7bc54132ade832ef1a07c" %}
+
+package:
+  name: nanodbc
+  version: "{{ version }}"
+
+about:
+  home: http://nanodbc.io/
+  license: MIT
+  summary: "A small C++ wrapper for the native C ODBC API"
+
+source:
+  url: https://github.com/nanodbc/nanodbc/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 1
+
+requirements:
+  build:
+    - {{ compiler("cxx") }}
+    - cmake
+    - make
+  host:
+    - unixodbc
+
+files:
+  - include/nanodbc/nanodbc.h
+  - lib/libnanodbc.*
+
+test:
+  commands:
+    - test -f ${PREFIX}/include/nanodbc/nanodbc.h

--- a/red-recipes/irods/4.2.8/build.sh
+++ b/red-recipes/irods/4.2.8/build.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -ex
+
+running_in_docker() {
+    if [ -f /.dockerenv ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+export TERM=dumb
+
+if running_in_docker ; then
+    echo "Running in Docker ... "
+fi
+
+pushd irods
+git submodule init && git submodule update
+popd
+
+[ -d build_irods ] || mkdir build_irods
+pushd build_irods
+cmake \
+    -D CMAKE_INSTALL_PREFIX=${PREFIX} \
+    -D CMAKE_INSTALL_LIBDIR=${PREFIX}/lib \
+    -D IRODS_EXTERNALS_FULLPATH_CLANG=${BUILD_PREFIX} \
+    -D IRODS_EXTERNALS_FULLPATH_CLANG_RUNTIME=${PREFIX} \
+    -D IRODS_EXTERNALS_FULLPATH_ARCHIVE=${PREFIX} \
+    -D IRODS_EXTERNALS_FULLPATH_AVRO=${PREFIX} \
+    -D IRODS_EXTERNALS_FULLPATH_BOOST=${PREFIX} \
+    -D IRODS_EXTERNALS_FULLPATH_CATCH2=${PREFIX} \
+    -D IRODS_EXTERNALS_FULLPATH_CPPZMQ=${PREFIX} \
+    -D IRODS_EXTERNALS_FULLPATH_FMT=${PREFIX} \
+    -D IRODS_EXTERNALS_FULLPATH_JANSSON=${PREFIX} \
+    -D IRODS_EXTERNALS_FULLPATH_JSON=${PREFIX} \
+    -D IRODS_EXTERNALS_FULLPATH_NANODBC=${PREFIX} \
+    -D IRODS_EXTERNALS_FULLPATH_ZMQ=${PREFIX} \
+    -D IRODS_LINUX_DISTRIBUTION_NAME='Ubuntu' \
+    -D IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR='12' \
+    -D IRODS_LINUX_DISTRIBUTION_VERSION_CODENAME='Precise' \
+    -D CMAKE_C_FLAGS="-I${PREFIX}/include" \
+    -D CMAKE_CXX_FLAGS='-Wno-deprecated-declarations' \
+    -D CMAKE_LD_FLAGS='-Wno-deprecated-declarations' \
+    -D CMAKE_EXE_LINKER_FLAGS="-Wl,-rpath-link,${PREFIX}/lib -fuse-ld=${LD}" \
+    -D CMAKE_C_COMPILER="${BUILD_PREFIX}/bin/clang" \
+    -D CMAKE_CXX_COMPILER="${BUILD_PREFIX}/bin/clang++" \
+    -D BUILD_UNIT_TESTS=OFF \
+    -D CMAKE_AR=${AR} \
+    -D CMAKE_LINKER=${LD} \
+    -D CPP=${CPP} \
+    ../irods
+make VERBOSE=1 -j 8 package
+make VERBOSE=1 install
+popd
+
+
+[ -d build_icommands ] || mkdir build_icommands
+pushd build_icommands
+cmake \
+    -D CMAKE_INSTALL_PREFIX=${PREFIX} \
+    -D CMAKE_INSTALL_LIBDIR=${PREFIX}/lib \
+    -D IRODS_EXTERNALS_FULLPATH_CLANG=${BUILD_PREFIX} \
+    -D IRODS_EXTERNALS_FULLPATH_CLANG_RUNTIME=${PREFIX} \
+    -D IRODS_LINUX_DISTRIBUTION_NAME='Ubuntu' \
+    -D IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR='12' \
+    -D IRODS_LINUX_DISTRIBUTION_VERSION_CODENAME='Precise' \
+    -D IRODS_DIR="${PREFIX}/lib/irods/cmake" \
+    -D CMAKE_C_FLAGS="-I${PREFIX}/include" \
+    -D CMAKE_CXX_FLAGS='-Wno-deprecated-declarations' \
+    -D CMAKE_LD_FLAGS='-Wno-deprecated-declarations' \
+    -D CMAKE_EXE_LINKER_FLAGS="-Wl,-rpath-link,${PREFIX}/lib -fuse-ld=${LD}" \
+    -D CMAKE_C_COMPILER="${BUILD_PREFIX}/bin/clang" \
+    -D CMAKE_CXX_COMPILER="${BUILD_PREFIX}/bin/clang++" \
+    -D CMAKE_AR=${AR} \
+    -D CMAKE_LINKER=${LD} \
+    -D CPP=${CPP} \
+    ../irods_client_icommands
+    
+make VERBOSE=1 -j 8 package
+make install
+popd
+

--- a/red-recipes/irods/4.2.8/conda_build_config.yaml
+++ b/red-recipes/irods/4.2.8/conda_build_config.yaml
@@ -1,0 +1,9 @@
+
+CFLAGS: >-
+  -O2
+  -fPIC
+  -ffunction-sections
+  -ftree-vectorize
+  -march=x86-64
+  -mtune=generic
+  -pipe

--- a/red-recipes/irods/4.2.8/irods.patch
+++ b/red-recipes/irods/4.2.8/irods.patch
@@ -1,0 +1,469 @@
+diff --git CMakeLists.txt CMakeLists.txt
+index dcfd763f9..0213eba00 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -27,36 +27,39 @@ macro(IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH_ADD_TO_IRODS_PACKAGE_DEPENDENCIE
+   list(APPEND IRODS_PACKAGE_DEPENDENCIES_LIST irods-externals-${DEPENDENCY_SUBDIRECTORY})
+ endmacro()
+ 
+-IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH(CLANG clang6.0-0)
+-IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH(CPPZMQ cppzmq4.2.3-0)
+-IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH_ADD_TO_IRODS_PACKAGE_DEPENDENCIES_LIST(ARCHIVE libarchive3.3.2-1)
+-IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH_ADD_TO_IRODS_PACKAGE_DEPENDENCIES_LIST(AVRO avro1.9.0-0)
+-IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH_ADD_TO_IRODS_PACKAGE_DEPENDENCIES_LIST(BOOST boost1.67.0-0)
+-IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH_ADD_TO_IRODS_PACKAGE_DEPENDENCIES_LIST(CLANG_RUNTIME clang-runtime6.0-0)
+-IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH_ADD_TO_IRODS_PACKAGE_DEPENDENCIES_LIST(ZMQ zeromq4-14.1.6-0)
+-IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH_ADD_TO_IRODS_PACKAGE_DEPENDENCIES_LIST(JSON json3.7.3-0)
+-IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH_ADD_TO_IRODS_PACKAGE_DEPENDENCIES_LIST(CATCH2 catch22.3.0-0)
+-IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH_ADD_TO_IRODS_PACKAGE_DEPENDENCIES_LIST(NANODBC nanodbc2.13.0-0)
+-IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH_ADD_TO_IRODS_PACKAGE_DEPENDENCIES_LIST(FMT fmt6.1.2-1)
++# IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH(CLANG)
++# IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH(CPPZMQ)
++# IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH_ADD_TO_IRODS_PACKAGE_DEPENDENCIES_LIST(ARCHIVE)
++# IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH_ADD_TO_IRODS_PACKAGE_DEPENDENCIES_LIST(AVRO)
++# IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH_ADD_TO_IRODS_PACKAGE_DEPENDENCIES_LIST(BOOST)
++# IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH_ADD_TO_IRODS_PACKAGE_DEPENDENCIES_LIST(CLANG_RUNTIME)
++# IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH_ADD_TO_IRODS_PACKAGE_DEPENDENCIES_LIST(ZMQ)
++# IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH_ADD_TO_IRODS_PACKAGE_DEPENDENCIES_LIST(JSON)
++# IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH_ADD_TO_IRODS_PACKAGE_DEPENDENCIES_LIST(CATCH2)
++# IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH_ADD_TO_IRODS_PACKAGE_DEPENDENCIES_LIST(NANODBC)
++# IRODS_MACRO_CHECK_DEPENDENCY_SET_FULLPATH_ADD_TO_IRODS_PACKAGE_DEPENDENCIES_LIST(FMT)
+ 
+ string(REPLACE ";" ", " IRODS_PACKAGE_DEPENDENCIES_STRING "${IRODS_PACKAGE_DEPENDENCIES_LIST}")
+ 
+-if (NOT CLANG_STATIC_ANALYZER)
+-  set(CLANG_STATIC_ANALYZER OFF CACHE BOOL "Choose whether to run Clang Static Analyzer." FORCE)
+-  message(STATUS "Setting CLANG_STATIC_ANALYZER to 'OFF'.")
+-  set(CMAKE_C_COMPILER ${IRODS_EXTERNALS_FULLPATH_CLANG}/bin/clang)
+-  set(CMAKE_CXX_COMPILER ${IRODS_EXTERNALS_FULLPATH_CLANG}/bin/clang++)
+-else()
+-  set(CLANG_STATIC_ANALYZER ON CACHE BOOL "Choose whether to run Clang Static Analyzer." FORCE)
+-  message(STATUS "Setting CLANG_STATIC_ANALYZER to 'ON'.")
+-  set(CMAKE_C_COMPILER ${IRODS_EXTERNALS_FULLPATH_CLANG}/bin/ccc-analyzer)
+-  set(CMAKE_CXX_COMPILER ${IRODS_EXTERNALS_FULLPATH_CLANG}/bin/c++-analyzer)
+-endif()
++# if (NOT CLANG_STATIC_ANALYZER)
++#   set(CLANG_STATIC_ANALYZER OFF CACHE BOOL "Choose whether to run Clang Static Analyzer." FORCE)
++#   message(STATUS "Setting CLANG_STATIC_ANALYZER to 'OFF'.")
++#   set(CMAKE_C_COMPILER ${IRODS_EXTERNALS_FULLPATH_CLANG}/bin/clang)
++#   set(CMAKE_CXX_COMPILER ${IRODS_EXTERNALS_FULLPATH_CLANG}/bin/clang++)
++# else()
++#   set(CLANG_STATIC_ANALYZER ON CACHE BOOL "Choose whether to run Clang Static Analyzer." FORCE)
++#   message(STATUS "Setting CLANG_STATIC_ANALYZER to 'ON'.")
++#   set(CMAKE_C_COMPILER ${IRODS_EXTERNALS_FULLPATH_CLANG}/bin/ccc-analyzer)
++#   set(CMAKE_CXX_COMPILER ${IRODS_EXTERNALS_FULLPATH_CLANG}/bin/c++-analyzer)
++# endif()
+ 
+-set(CMAKE_EXE_LINKER_FLAGS_INIT "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
++set(CMAKE_EXE_LINKER_FLAGS_INIT "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath-link,${CMAKE_INSTALL_PREFIX}")
+ 
+ project(irods C CXX)
+ 
++include(GNUInstallDirs)
++include_directories(AFTER ${CMAKE_INSTALL_PREFIX}/include)
++# include_directories(${CMAKE_INSTALL_PREFIX}/lib)
+ set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
+ 
+ if (NOT CPACK_PACKAGING_INSTALL_PREFIX)
+@@ -64,18 +67,22 @@ if (NOT CPACK_PACKAGING_INSTALL_PREFIX)
+   message(STATUS "Setting unspecified CPACK_PACKAGING_INSTALL_PREFIX to '${CPACK_PACKAGING_INSTALL_PREFIX}'. This is the correct setting for normal builds.")
+ endif()
+ 
++set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+-set(CMAKE_INSTALL_RPATH ${IRODS_EXTERNALS_FULLPATH_CLANG_RUNTIME}/lib)
++set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
++
++set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--export-dynamic") # export-dynamic so stacktrace entries from executables have function names
++set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-z,defs")
++set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,defs")
++add_compile_options(-Wall -Wextra -Wno-unused-function -Wno-unused-parameter)
+ 
+-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -Wl,--export-dynamic -pthread") # export-dynamic so stacktrace entries from executables have function names
+-set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -stdlib=libc++ -Wl,-z,defs -pthread")
+-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -stdlib=libc++ -Wl,-z,defs -pthread")
+-add_compile_options(-nostdinc++ -Wall -Wextra -Werror -Wno-unused-function -Wno-unused-parameter)
+-link_libraries(c++abi)
+-include_directories(${IRODS_EXTERNALS_FULLPATH_CLANG}/include/c++/v1
+-                    ${IRODS_EXTERNALS_FULLPATH_JSON}/include)
++include_directories(${IRODS_EXTERNALS_FULLPATH_JSON}/include/nlohmann
++                    ${IRODS_EXTERNALS_FULLPATH_CATCH2}/include/catch2)
+ 
++set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
++set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+ find_package(Threads REQUIRED)
++
+ find_package(OpenSSL REQUIRED)
+ if (NOT PAM_LIBRARY)
+   find_library(PAM_LIBRARY pam)
+@@ -98,31 +105,33 @@ set(IRODS_COMPILE_DEFINITIONS ${IRODS_PLATFORM_STRING} _LARGEFILE_SOURCE _FILE_O
+ 
+ if (NOT IRODS_LINUX_DISTRIBUTION_NAME)
+   execute_process(
+-    COMMAND "python" "-c" "from __future__ import print_function; import platform; print(platform.linux_distribution()[0].split()[0].strip().lower(), end='')"
++    COMMAND "lsb_release" "-i" "-s"
+     RESULT_VARIABLE IRODS_EXECUTE_PROCESS_RESULT_LINUX_DISTRIBUTION_NAME
+     OUTPUT_VARIABLE IRODS_LINUX_DISTRIBUTION_NAME
+     )
++  string(STRIP ${IRODS_LINUX_DISTRIBUTION_NAME} IRODS_LINUX_DISTRIBUTION_NAME)
+   if (NOT ${IRODS_EXECUTE_PROCESS_RESULT_LINUX_DISTRIBUTION_NAME} STREQUAL "0")
+     message(FATAL_ERROR "Linux platform name detection failed\n${IRODS_EXECUTE_PROCESS_RESULT_LINUX_DISTRIBUTION_NAME}")
+   endif()
+-  set(IRODS_LINUX_DISTRIBUTION_NAME ${IRODS_LINUX_DISTRIBUTION_NAME} CACHE STRING "Linux distribution name, e.g. {ubuntu, centos, ...}." FORCE)
++  set(IRODS_LINUX_DISTRIBUTION_NAME ${IRODS_LINUX_DISTRIBUTION_NAME} CACHE STRING "Linux distribution name, e.g. {Ubuntu, CentOS, ...}." FORCE)
+   message(STATUS "Setting unspecified IRODS_LINUX_DISTRIBUTION_NAME to '${IRODS_LINUX_DISTRIBUTION_NAME}'")
+ endif()
+ 
+ if (NOT IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR)
+   execute_process(
+-    COMMAND "python" "-c" "from __future__ import print_function; import platform; print(platform.linux_distribution()[1].strip().lower().split('.')[0], end='')"
++    COMMAND "lsb_release" "-r" "-s"
+     RESULT_VARIABLE IRODS_EXECUTE_PROCESS_RESULT_LINUX_DISTRIBUTION_VERSION_MAJOR
+     OUTPUT_VARIABLE IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR
+     )
++  string(STRIP ${IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR} IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR)
+   if (NOT ${IRODS_EXECUTE_PROCESS_RESULT_LINUX_DISTRIBUTION_VERSION_MAJOR} STREQUAL "0")
+     message(FATAL_ERROR "Linux platform name detection failed\n${IRODS_EXECUTE_PROCESS_RESULT_LINUX_DISTRIBUTION_VERSION_MAJOR}")
+   endif()
+-  set(IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR ${IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR} CACHE STRING "Linux distribution name, e.g. {ubuntu, centos, ...}." FORCE)
++  set(IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR ${IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR} CACHE STRING "Linux distribution name, e.g. {Ubuntu, CentOS, ...}." FORCE)
+   message(STATUS "Setting unspecified IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR to '${IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR}'")
+ endif()
+ 
+-if(IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "ubuntu" OR IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "debian")
++if(IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "Ubuntu" OR IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "Debian")
+   if (NOT IRODS_LINUX_DISTRIBUTION_VERSION_CODENAME)
+     execute_process(
+       COMMAND "lsb_release" "-s" "-c"
+@@ -133,19 +142,19 @@ if(IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "ubuntu" OR IRODS_LINUX_DISTRIBUTION_N
+     if (NOT ${IRODS_EXECUTE_PROCESS_RESULT_LINUX_DISTRIBUTION_VERSION_CODENAME} STREQUAL "0")
+       message(FATAL_ERROR "Linux lsb_release shortname detection failed\n${IRODS_EXECUTE_PROCESS_RESULT_LINUX_DISTRIBUTION_VERSION_CODENAME}")
+     endif()
+-    set(IRODS_LINUX_DISTRIBUTION_VERSION_CODENAME ${IRODS_LINUX_DISTRIBUTION_VERSION_CODENAME} CACHE STRING "Linux distribution version codename, e.g. {precise, wheezy, trusty, jessie, ...}." FORCE)
++    set(IRODS_LINUX_DISTRIBUTION_VERSION_CODENAME ${IRODS_LINUX_DISTRIBUTION_VERSION_CODENAME} CACHE STRING "Linux distribution version codename, e.g. {Precise, Wheezy, Trusty, Jessie, ...}." FORCE)
+     message(STATUS "Setting unspecified IRODS_LINUX_DISTRIBUTION_VERSION_CODENAME to '${IRODS_LINUX_DISTRIBUTION_VERSION_CODENAME}'")
+   endif()
+ endif()
+ 
+ if (NOT CPACK_GENERATOR)
+-  if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "arch")
++  if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "Arch")
+     set(CPACK_GENERATOR TGZ CACHE STRING "CPack generator to use, e.g. {DEB, RPM, TGZ}." FORCE)
+     message(STATUS "Setting unspecified CPACK_GENERATOR to ${CPACK_GENERATOR}. This is the correct setting for normal builds.")
+-  elseif(IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "ubuntu" OR IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "debian")
++  elseif(IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "Ubuntu" OR IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "Debian")
+     set(CPACK_GENERATOR DEB CACHE STRING "CPack generator to use, e.g. {DEB, RPM, TGZ}." FORCE)
+     message(STATUS "Setting unspecified CPACK_GENERATOR to ${CPACK_GENERATOR}. This is the correct setting for normal builds.")
+-  elseif(IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos" OR IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "opensuse" OR IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "fedora")
++  elseif(IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "CentOS" OR IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "openSUSE project" OR IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "Fedora")
+     set(CPACK_GENERATOR RPM CACHE STRING "CPack generator to use, e.g. {DEB, RPM, TGZ}." FORCE)
+     message(STATUS "Setting unspecified CPACK_GENERATOR to ${CPACK_GENERATOR}. This is the correct setting for normal builds.")
+   else()
+@@ -205,7 +214,7 @@ git submodule update --init")
+ endif()
+ 
+ add_custom_command(
+-  OUTPUT ${CMAKE_BINARY_DIR}/lib/core/include/server_control_plane_command.hpp
++ OUTPUT ${CMAKE_BINARY_DIR}/lib/core/include/server_control_plane_command.hpp
+   COMMAND ${IRODS_EXTERNALS_FULLPATH_AVRO}/bin/avrogencpp -n irods -o ${CMAKE_BINARY_DIR}/lib/core/include/server_control_plane_command.hpp -i ${CMAKE_SOURCE_DIR}/irods_schema_messaging/v1/server_control_plane_command.json
+   MAIN_DEPENDENCY ${CMAKE_SOURCE_DIR}/irods_schema_messaging/v1/server_control_plane_command.json
+   )
+@@ -1435,8 +1444,8 @@ set_property(TARGET genOSAuth PROPERTY CXX_STANDARD ${IRODS_CXX_STANDARD})
+ target_compile_definitions(genOSAuth PRIVATE ${IRODS_COMPILE_DEFINITIONS})
+ target_compile_options(genOSAuth PRIVATE -Wno-write-strings)
+ 
+-set(IRODS_HOME_DIRECTORY var/lib/irods)
+-set(IRODS_PLUGINS_DIRECTORY usr/lib/irods/plugins)
++set(IRODS_HOME_DIRECTORY ${CMAKE_INSTALL_LOCALSTATEDIR}/lib/irods)
++set(IRODS_PLUGINS_DIRECTORY ${CMAKE_INSTALL_LIBDIR}/irods/plugins)
+ 
+ add_subdirectory(plugins/api)
+ add_subdirectory(plugins/auth)
+@@ -1492,13 +1501,13 @@ set(CPACK_DEBIAN_${IRODS_PACKAGE_COMPONENT_POSTGRES_NAME_UPPERCASE}_PACKAGE_DEPE
+ set(CPACK_DEBIAN_${IRODS_PACKAGE_COMPONENT_POSTGRES_NAME_UPPERCASE}_PACKAGE_CONTROL_EXTRA "${CMAKE_SOURCE_DIR}/plugins/database/packaging/preinst;${CMAKE_SOURCE_DIR}/plugins/database/packaging/postinst;${CMAKE_SOURCE_DIR}/plugins/database/packaging/postrm;")
+ 
+ set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_POSTGRES_NAME}_PACKAGE_NAME "irods-database-plugin-postgres")
+-if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos")
++if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "CentOS")
+   if (IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR STREQUAL "6" OR IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR STREQUAL "7")
+     set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_POSTGRES_NAME}_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-server = ${IRODS_VERSION}, unixODBC, postgresql, authd, postgresql-odbc")
+   else()
+     message(FATAL "Unsupported CentOS major version: ${IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR}")
+   endif()
+-elseif (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "opensuse")
++elseif (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "openSUSE project")
+   set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_POSTGRES_NAME}_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-server = ${IRODS_VERSION}, unixODBC, postgresql, psqlODBC")
+ endif()
+ set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_POSTGRES_NAME}_PRE_INSTALL_SCRIPT_FILE "${CMAKE_SOURCE_DIR}/plugins/database/packaging/preinst")
+@@ -1507,19 +1516,19 @@ set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_POSTGRES_NAME}_POST_UNINSTALL_SCRIPT_FIL
+ 
+ # mysql
+ set(CPACK_DEBIAN_${IRODS_PACKAGE_COMPONENT_MYSQL_NAME_UPPERCASE}_PACKAGE_NAME "irods-database-plugin-mysql")
+-if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "ubuntu")
++if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "Ubuntu")
+   set(CPACK_DEBIAN_${IRODS_PACKAGE_COMPONENT_MYSQL_NAME_UPPERCASE}_PACKAGE_DEPENDS "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-server (= ${CPACK_DEBIAN_PACKAGE_VERSION}), unixodbc, mysql-client, libc6")
+ endif()
+ set(CPACK_DEBIAN_${IRODS_PACKAGE_COMPONENT_MYSQL_NAME_UPPERCASE}_PACKAGE_CONTROL_EXTRA "${CMAKE_SOURCE_DIR}/plugins/database/packaging/preinst;${CMAKE_SOURCE_DIR}/plugins/database/packaging/postinst;${CMAKE_SOURCE_DIR}/plugins/database/packaging/postrm;")
+ 
+ set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_MYSQL_NAME}_PACKAGE_NAME "irods-database-plugin-mysql")
+-if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos")
++if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "CentOS")
+   if (IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR STREQUAL "6" OR IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR STREQUAL "7")
+     set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_MYSQL_NAME}_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-server = ${IRODS_VERSION}, mysql, unixODBC, mysql-connector-odbc")
+   else()
+     message(FATAL "Unsupported CentOS major version: ${IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR}")
+   endif()
+-elseif (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "opensuse")
++elseif (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "openSUSE project")
+   set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_MYSQL_NAME}_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-server = ${IRODS_VERSION}, mysql-client, unixODBC, MyODBC-unixODBC")
+ endif()
+ set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_MYSQL_NAME}_PRE_INSTALL_SCRIPT_FILE "${CMAKE_SOURCE_DIR}/plugins/database/packaging/preinst")
+@@ -1532,7 +1541,7 @@ set(CPACK_DEBIAN_${IRODS_PACKAGE_COMPONENT_ORACLE_NAME_UPPERCASE}_PACKAGE_DEPEND
+ set(CPACK_DEBIAN_${IRODS_PACKAGE_COMPONENT_ORACLE_NAME_UPPERCASE}_PACKAGE_CONTROL_EXTRA "${CMAKE_SOURCE_DIR}/plugins/database/packaging/preinst;${CMAKE_SOURCE_DIR}/plugins/database/packaging/postinst;${CMAKE_SOURCE_DIR}/plugins/database/packaging/postrm;")
+ 
+ set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_ORACLE_NAME}_PACKAGE_NAME "irods-database-plugin-oracle")
+-if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos")
++if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "CentOS")
+   if (IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR STREQUAL "6")
+     set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_ORACLE_NAME}_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-server = ${IRODS_VERSION}, unixODBC")
+   elseif (IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR STREQUAL "7")
+@@ -1540,7 +1549,7 @@ if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos")
+   else()
+     message(FATAL "Unsupported CentOS major version: ${IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR}")
+   endif()
+-elseif (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "opensuse")
++elseif (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "openSUSE project")
+   set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_ORACLE_NAME}_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-server = ${IRODS_VERSION}, unixODBC")
+ endif()
+ set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_ORACLE_NAME}_PRE_INSTALL_SCRIPT_FILE "${CMAKE_SOURCE_DIR}/plugins/database/packaging/preinst")
+@@ -1597,20 +1606,20 @@ install(
+   )
+ 
+ 
+-set(IRODS_INCLUDE_DIRS usr/include/irods)
++set(IRODS_INCLUDE_DIRS include/irods)
+ 
+ include(CMakePackageConfigHelpers)
+ configure_package_config_file(
+   ${CMAKE_SOURCE_DIR}/cmake/IRODSConfig.cmake.not_yet_installed.in
+   ${CMAKE_BINARY_DIR}/IRODSConfig.cmake.not_yet_installed # suffix prevents cmake's find_package() from using this copy of the file
+-  INSTALL_DESTINATION usr/lib/irods/cmake
++  INSTALL_DESTINATION  ${CMAKE_INSTALL_LIBDIR}/irods/cmake
+   PATH_VARS IRODS_INCLUDE_DIRS
+   )
+ 
+ install(
+   FILES
+   ${CMAKE_BINARY_DIR}/IRODSConfig.cmake.not_yet_installed
+-  DESTINATION usr/lib/irods/cmake
++  DESTINATION  ${CMAKE_INSTALL_LIBDIR}/irods/cmake
+   COMPONENT ${IRODS_PACKAGE_COMPONENT_DEVELOPMENT_NAME}
+   RENAME IRODSConfig.cmake
+   )
+@@ -1624,7 +1633,7 @@ write_basic_package_version_file(
+ install(
+   FILES
+   ${CMAKE_BINARY_DIR}/IRODSConfigVersion.cmake
+-  DESTINATION usr/lib/irods/cmake
++  DESTINATION  ${CMAKE_INSTALL_LIBDIR}/irods/cmake
+   COMPONENT ${IRODS_PACKAGE_COMPONENT_DEVELOPMENT_NAME}
+   )
+ 
+@@ -1649,3 +1658,5 @@ foreach(DATABASE_PLUGIN postgres oracle mysql)
+ endforeach()
+ 
+ include(CPack)
++
++install(TARGETS irods_client DESTINATION ${CMAKE_INSTALL_LIBDIR})
+diff --git cmake/development_library.cmake cmake/development_library.cmake
+index a555a646e..043e01fb5 100644
+--- cmake/development_library.cmake
++++ cmake/development_library.cmake
+@@ -5,7 +5,7 @@ install(
+   TARGETS
+     RodsAPIs
+   ARCHIVE
+-    DESTINATION usr/lib
++    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     COMPONENT ${IRODS_PACKAGE_COMPONENT_DEVELOPMENT_NAME}
+   )
+ 
+@@ -566,7 +566,7 @@ install(
+   ${IRODS_SERVER_ICAT_INCLUDE_HEADERS}
+   ${IRODS_SERVER_RE_INCLUDE_HEADERS}
+   ${IRODS_SERVER_DRIVERS_INCLUDE_HEADERS}
+-  DESTINATION usr/include/irods
++  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/irods
+   COMPONENT ${IRODS_PACKAGE_COMPONENT_DEVELOPMENT_NAME}
+   )
+ 
+@@ -581,7 +581,7 @@ install(
+ # NOTE: The trailing slash in the "DIRECTORY" argument is significant. DO NOT REMOVE IT!
+ install(
+   DIRECTORY ${CMAKE_SOURCE_DIR}/lib/filesystem/include/
+-  DESTINATION usr/include/irods
++  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/irods
+   COMPONENT ${IRODS_PACKAGE_COMPONENT_DEVELOPMENT_NAME}
+   FILES_MATCHING
+     PATTERN */filesystem.hpp
+@@ -609,7 +609,7 @@ install(
+ # NOTE: The trailing slash in the "DIRECTORY" argument is significant. DO NOT REMOVE IT!
+ install(
+   DIRECTORY ${CMAKE_SOURCE_DIR}/plugins/api/include/
+-  DESTINATION usr/include/irods/plugins/api
++  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/irods/plugins/api
+   COMPONENT ${IRODS_PACKAGE_COMPONENT_DEVELOPMENT_NAME}
+   FILES_MATCHING
+     PATTERN */api_plugin_number.h
+@@ -628,7 +628,7 @@ install(
+ # NOTE: The trailing slash in the "DIRECTORY" argument is significant. DO NOT REMOVE IT!
+ install(
+   DIRECTORY ${CMAKE_SOURCE_DIR}/lib/core/include/transport/
+-  DESTINATION usr/include/irods/transport
++  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/irods/transport
+   COMPONENT ${IRODS_PACKAGE_COMPONENT_DEVELOPMENT_NAME}
+   FILES_MATCHING
+     PATTERN */transport/transport.hpp
+@@ -638,7 +638,7 @@ install(
+ install(
+   EXPORT
+   IRODSTargets
+-  DESTINATION usr/lib/irods/cmake
++  DESTINATION ${CMAKE_INSTALL_LIBDIR}/irods/cmake
+   COMPONENT ${IRODS_PACKAGE_COMPONENT_DEVELOPMENT_NAME}
+   )
+ 
+@@ -646,8 +646,8 @@ set(CPACK_DEBIAN_${IRODS_PACKAGE_COMPONENT_DEVELOPMENT_NAME_UPPERCASE}_PACKAGE_N
+ set(CPACK_DEBIAN_${IRODS_PACKAGE_COMPONENT_DEVELOPMENT_NAME_UPPERCASE}_PACKAGE_DEPENDS "libssl-dev")
+ 
+ set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_DEVELOPMENT_NAME}_PACKAGE_NAME "irods-devel")
+-if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos")
++if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "CentOS")
+   set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_SERVER_NAME}_PACKAGE_REQUIRES "openssl-devel")
+-elseif (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "opensuse")
++elseif (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "OpenSUSE project")
+   set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_SERVER_NAME}_PACKAGE_REQUIRES "libopenssl-devel")
+ endif()
+diff --git cmake/runtime_library.cmake cmake/runtime_library.cmake
+index 408c27fe0..806b3d7cd 100644
+--- cmake/runtime_library.cmake
++++ cmake/runtime_library.cmake
+@@ -6,7 +6,7 @@ install(
+   irods_server
+   EXPORT IRODSTargets
+   LIBRARY
+-  DESTINATION usr/lib
++  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   COMPONENT ${IRODS_PACKAGE_COMPONENT_RUNTIME_NAME}
+   )
+ 
+@@ -15,9 +15,9 @@ set(CPACK_DEBIAN_${IRODS_PACKAGE_COMPONENT_RUNTIME_NAME_UPPERCASE}_PACKAGE_DEPEN
+ 
+ 
+ set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_RUNTIME_NAME}_PACKAGE_NAME "irods-runtime")
+-if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos")
++if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "CentOS")
+   set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_RUNTIME_NAME}_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, libxml2, openssl, python, python-psutil, python-requests, python-jsonschema")
+-elseif (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "opensuse")
++elseif (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "OpenSUSE project")
+   set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_RUNTIME_NAME}_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, libopenssl1_0_0, python, openssl, python-psutil, python-requests, python-jsonschema")
+ endif()
+ 
+diff --git cmake/server.cmake cmake/server.cmake
+index 4a032ecd9..2d8b9e5e0 100644
+--- cmake/server.cmake
++++ cmake/server.cmake
+@@ -8,7 +8,7 @@ install(
+   irodsXmsgServer
+   hostname_resolves_to_local_address
+   RUNTIME
+-  DESTINATION usr/sbin
++  DESTINATION sbin
+   COMPONENT ${IRODS_PACKAGE_COMPONENT_SERVER_NAME}
+   )
+ 
+@@ -145,7 +145,7 @@ install(
+   TARGETS
+   irodsPamAuthCheck
+   RUNTIME
+-  DESTINATION usr/sbin
++  DESTINATION sbin
+   COMPONENT ${IRODS_PACKAGE_COMPONENT_SERVER_NAME}
+   PERMISSIONS SETUID OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+   )
+@@ -154,7 +154,7 @@ install(
+   TARGETS
+   genOSAuth
+   RUNTIME
+-  DESTINATION var/lib/irods/clients/bin
++  DESTINATION lib/irods/clients/bin
+   COMPONENT ${IRODS_PACKAGE_COMPONENT_SERVER_NAME}
+   )
+ 
+@@ -175,16 +175,16 @@ set(CPACK_DEBIAN_${IRODS_PACKAGE_COMPONENT_SERVER_NAME_UPPERCASE}_PACKAGE_BREAKS
+ set(CPACK_DEBIAN_${IRODS_PACKAGE_COMPONENT_SERVER_NAME_UPPERCASE}_PACKAGE_REPLACES "irods-icat, irods-resource")
+ set(CPACK_DEBIAN_${IRODS_PACKAGE_COMPONENT_SERVER_NAME_UPPERCASE}_PACKAGE_CONTROL_EXTRA "${CMAKE_SOURCE_DIR}/preinst;${CMAKE_SOURCE_DIR}/postinst;${CMAKE_SOURCE_DIR}/prerm;")
+ 
+-if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "ubuntu" AND IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR STREQUAL "12")
++if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "Ubuntu" AND IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR STREQUAL "12")
+ else()
+   set(CPACK_DEBIAN_${IRODS_PACKAGE_COMPONENT_SERVER_NAME_UPPERCASE}_PACKAGE_DEPENDS "${CPACK_DEBIAN_${IRODS_PACKAGE_COMPONENT_SERVER_NAME_UPPERCASE}_PACKAGE_DEPENDS}, python-jsonschema")
+ endif()
+ 
+ 
+ set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_SERVER_NAME}_PACKAGE_NAME "irods-server")
+-if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos")
++if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "CentOS")
+   set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_SERVER_NAME}_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime = ${IRODS_VERSION}, irods-icommands = ${IRODS_VERSION}, openssl, python, python-psutil, python-requests, python-jsonschema")
+-elseif (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "opensuse")
++elseif (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "OpenSUSE project")
+   set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_SERVER_NAME}_PACKAGE_REQUIRES "${IRODS_PACKAGE_DEPENDENCIES_STRING}, irods-runtime = ${IRODS_VERSION}, irods-icommands = ${IRODS_VERSION}, libopenssl1_0_0, python, openssl, python-psutil, python-requests, python-jsonschema")
+ endif()
+ set(CPACK_RPM_${IRODS_PACKAGE_COMPONENT_SERVER_NAME}_PRE_INSTALL_SCRIPT_FILE "${CMAKE_SOURCE_DIR}/preinst")
+diff --git lib/core/src/irods_default_paths.cpp lib/core/src/irods_default_paths.cpp
+index 051658f09..eca9ea661 100644
+--- lib/core/src/irods_default_paths.cpp
++++ lib/core/src/irods_default_paths.cpp
+@@ -18,7 +18,7 @@ namespace irods {
+         try {
+             boost::filesystem::path path{dl_info.dli_fname};
+             path = boost::filesystem::canonical(path);
+-            path.remove_filename().remove_filename().remove_filename(); // Removes filename and the two directories (usr and lib) between libirods_common.so and base of irods install
++            path.remove_filename().remove_filename(); // Removes the filename and the lib directory between libirods_common.so and the base of the irods install
+             return path;
+         } catch(const boost::filesystem::filesystem_error& e) {
+             THROW(-1, e.what());
+@@ -42,7 +42,7 @@ namespace irods {
+     boost::filesystem::path
+     get_irods_default_plugin_directory() {
+         boost::filesystem::path path{get_irods_root_directory()};
+-        path.append("usr").append("lib").append("irods").append("plugins");
++        path.append("lib").append("irods").append("plugins");
+         return path;
+     }
+ }
+diff --git lib/core/src/user_administration.cpp lib/core/src/user_administration.cpp
+index a66223d68..71ee40369 100644
+--- lib/core/src/user_administration.cpp
++++ lib/core/src/user_administration.cpp
+@@ -18,6 +18,7 @@
+ 
+ #include <array>
+ #include <iostream>
++#include <cstring>
+ 
+ namespace irods::experimental::administration::NAMESPACE_IMPL
+ {
+diff --git plugins/database/CMakeLists.txt plugins/database/CMakeLists.txt
+index 3a1b55e5e..ffd8b03f9 100644
+--- plugins/database/CMakeLists.txt
++++ plugins/database/CMakeLists.txt
+@@ -42,7 +42,7 @@ foreach(PLUGIN ${IRODS_DATABASE_PLUGINS})
+ 
+   add_custom_command(
+     OUTPUT ${CMAKE_BINARY_DIR}/icatSysTables_${PLUGIN}.sql
+-    COMMAND cpp -E -P -D${PLUGIN} ${CMAKE_BINARY_DIR}/plugins/database/src/icatSysTables.sql.pp ${CMAKE_BINARY_DIR}/icatSysTables_${PLUGIN}.sql
++    COMMAND ${CPP} -E -P -D${PLUGIN} ${CMAKE_BINARY_DIR}/plugins/database/src/icatSysTables.sql.pp ${CMAKE_BINARY_DIR}/icatSysTables_${PLUGIN}.sql
+     MAIN_DEPENDENCY ${CMAKE_BINARY_DIR}/plugins/database/src/icatSysTables.sql.pp
+     )
+   add_custom_target(IRODS_PHONY_TARGET_icatSysTables_${PLUGIN}.sql ALL DEPENDS ${CMAKE_BINARY_DIR}/icatSysTables_${PLUGIN}.sql) # Forces execution of custom_command

--- a/red-recipes/irods/4.2.8/irods_icommands.patch
+++ b/red-recipes/irods/4.2.8/irods_icommands.patch
@@ -1,0 +1,108 @@
+diff --git CMakeLists.txt CMakeLists.txt
+index feb5feb..4b61b38 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -3,15 +3,16 @@ include(${CMAKE_SOURCE_DIR}/cmake/RequireOutOfSourceBuild.cmake)
+ 
+ find_package(IRODS 4.2.8 EXACT REQUIRED CONFIG)
+ 
+-set(CMAKE_C_COMPILER ${IRODS_EXTERNALS_FULLPATH_CLANG}/bin/clang)
+-set(CMAKE_CXX_COMPILER ${IRODS_EXTERNALS_FULLPATH_CLANG}/bin/clang++)
++# set(CMAKE_C_COMPILER ${IRODS_EXTERNALS_FULLPATH_CLANG}/bin/clang)
++# set(CMAKE_CXX_COMPILER ${IRODS_EXTERNALS_FULLPATH_CLANG}/bin/clang++)
+ 
+-set(CMAKE_EXE_LINKER_FLAGS_INIT "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
++set(CMAKE_EXE_LINKER_FLAGS_INIT "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath-link,${CMAKE_INSTALL_PREFIX}")
+ 
+ project(icommands C CXX)
+ 
+ set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
+ 
++include(GNUInstallDirs)
+ include(${IRODS_TARGETS_PATH})
+ 
+ if (NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
+@@ -24,16 +25,17 @@ if (NOT CPACK_PACKAGING_INSTALL_PREFIX)
+   message(STATUS "Setting unspecified CPACK_PACKAGING_INSTALL_PREFIX to '${CPACK_PACKAGING_INSTALL_PREFIX}'. This is the correct setting for normal builds.")
+ endif()
+ 
+-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+-set(CMAKE_INSTALL_RPATH ${IRODS_EXTERNALS_FULLPATH_CLANG_RUNTIME}/lib)
+ set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
++set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
++set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
+ 
+-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
+-set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -stdlib=libc++")
+-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -stdlib=libc++")
+-add_compile_options(-nostdinc++ -Wall -Wextra -Werror -Wno-unused-parameter)
+-link_libraries(c++abi)
+-include_directories(${IRODS_EXTERNALS_FULLPATH_CLANG}/include/c++/v1)
++set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,defs")
++set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-z,defs")
++set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,defs")
++add_compile_options(-Wall -Wextra -Werror -Wno-unused-parameter)
++
++include_directories(${IRODS_EXTERNALS_FULLPATH_JSON}/include/nlohmann)
++include_directories(AFTER ${CMAKE_INSTALL_PREFIX}/include)
+ 
+ set(
+   IRODS_CLIENT_ICOMMANDS_EXECUTABLES
+@@ -126,10 +128,10 @@ foreach(EXECUTABLE ${IRODS_CLIENT_ICOMMANDS_EXECUTABLES})
+     TARGETS
+     ${EXECUTABLE}
+     RUNTIME
+-    DESTINATION usr/bin
++    DESTINATION ${CMAKE_INSTALL_BINDIR}
+     )
+ 
+-  if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos")
++  if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "CentOS")
+     if (IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR STREQUAL "6")
+       continue()
+     endif()
+@@ -148,7 +150,7 @@ foreach(EXECUTABLE ${IRODS_CLIENT_ICOMMANDS_EXECUTABLES})
+   install(
+     FILES
+     ${CMAKE_BINARY_DIR}/man/${EXECUTABLE}.1.gz
+-    DESTINATION usr/share/man/man1
++    DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
+     )
+ endforeach()
+ 
+@@ -161,11 +163,11 @@ foreach(IRODS_CLIENT_ICOMMANDS_SCRIPT ${IRODS_CLIENT_ICOMMANDS_SCRIPTS})
+   install(
+     FILES
+     ${CMAKE_SOURCE_DIR}/bin/${IRODS_CLIENT_ICOMMANDS_SCRIPT}
+-    DESTINATION usr/bin
++    DESTINATION ${CMAKE_INSTALL_BINDIR}
+     PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+     )
+ 
+-  if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "centos")
++  if (IRODS_LINUX_DISTRIBUTION_NAME STREQUAL "CentOS")
+     if (IRODS_LINUX_DISTRIBUTION_VERSION_MAJOR STREQUAL "6")
+       continue()
+     endif()
+@@ -180,13 +182,13 @@ foreach(IRODS_CLIENT_ICOMMANDS_SCRIPT ${IRODS_CLIENT_ICOMMANDS_SCRIPTS})
+   install(
+     FILES
+     ${CMAKE_BINARY_DIR}/man/${IRODS_CLIENT_ICOMMANDS_SCRIPT}.1.gz
+-    DESTINATION usr/share/man/man1
++    DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
+     )
+ endforeach()
+ 
+ install(
+   DIRECTORY ${CMAKE_SOURCE_DIR}/test
+-  DESTINATION var/lib/irods/clients/icommands
++  DESTINATION ${CMAKE_INSTALL_LIBDIR}/irods/clients/icommands
+   )
+ 
+ 
+@@ -243,3 +245,5 @@ if (NOT CPACK_GENERATOR)
+ endif()
+ 
+ include(CPack)
++
++install(TARGETS ${IRODS_CLIENT_ICOMMANDS_EXECUTABLES} DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/red-recipes/irods/4.2.8/meta.yaml
+++ b/red-recipes/irods/4.2.8/meta.yaml
@@ -1,0 +1,156 @@
+{% set version = "4.2.8" %}
+{% set clang_version = "8.0.1" %}
+
+package:
+  name: irods
+  version: "{{ version }}"
+
+about:
+  home: https://irods.org
+  license: BSD
+  summary: "Open Source Data Management Software."
+
+build:
+  number: 17
+
+source:
+  - git_url: https://github.com/irods/irods.git
+    git_rev: "{{ version }}"
+    folder: irods
+    patches:
+      - irods.patch
+  - git_url: https://github.com/irods/irods_client_icommands.git
+    git_rev: "{{ version }}"
+    folder: irods_client_icommands
+    patches:
+      - irods_icommands.patch
+
+requirements:
+  build:
+    - cmake >=3.5.0
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - clang =={{ clang_version }}
+    - clangxx =={{ clang_version }}
+    - make
+    - help2man
+  host:
+    - avrocpp-dev
+    - catch2
+    - cppzmq
+    - fmt
+    - json
+    - krb5-dev
+    - libarchive-dev
+    - libboost-dev
+    - libjansson-dev
+    - libpam-dev
+    - libssl-dev
+    - nanodbc
+    - unixodbc
+    - zeromq
+
+outputs:
+  - name: irods-runtime
+    version: {{ version }}
+    requirements:
+      run:
+        - fmt
+        - libarchive
+        - libavrocpp
+        - libboost
+        - libjansson
+        - libkrb5
+        - libpam
+        - libssl
+        - zeromq
+    files:
+      - lib/irods/plugins
+      - lib/libirods_client.so*
+      - lib/libirods_common.so*
+      - lib/libirods_plugin_dependencies.so*
+      - lib/libirods_server.so*
+
+  - name: irods-dev
+    version: {{ version }}
+    requirements:
+      run:
+        - {{ pin_subpackage("irods-runtime", exact=True) }}
+    files:
+      - include/irods
+      - lib/irods/externals
+      - lib/libRodsAPIs.a
+      - lib/libirods_client.a
+      - lib/libirods_client_api.a
+      - lib/libirods_client_api_table.a
+      - lib/libirods_client_core.a
+      - lib/libirods_client_plugins.a
+      - lib/libirods_server.a
+      - share/irods
+
+  - name: irods-icommands
+    version: {{ version }}
+    requirements:
+      run:
+        - {{ pin_subpackage("irods-runtime", exact=True) }}
+        - fmt
+        - libarchive
+        - libavrocpp
+        - libboost
+        - libjansson
+        - libkrb5
+        - libpam
+        - libssl
+        - zeromq
+    files:
+      - bin/iadmin
+      - bin/ibun
+      - bin/ichksum
+      - bin/ichmod
+      - bin/icp
+      - bin/idbug
+      - bin/ienv
+      - bin/ierror
+      - bin/iexecmd
+      - bin/iexit
+      - bin/ifsck
+      - bin/iget
+      - bin/igroupadmin
+      - bin/ihelp
+      - bin/iinit
+      - bin/ils
+      - bin/ilsresc
+      - bin/imcoll
+      - bin/imeta
+      - bin/imiscsvrinfo
+      - bin/imkdir
+      - bin/imv
+      - bin/ipasswd
+      - bin/iphybun
+      - bin/iphymv
+      - bin/ips
+      - bin/iput
+      - bin/ipwd
+      - bin/iqdel
+      - bin/iqmod
+      - bin/iqmod
+      - bin/iqstat
+      - bin/iquest
+      - bin/iquota
+      - bin/irepl
+      - bin/irm
+      - bin/irmtrash
+      - bin/irsync
+      - bin/irule
+      - bin/iscan
+      - bin/isysmeta
+      - bin/iticket
+      - bin/itrim
+      - bin/iuserinfo
+      - bin/ixmsg
+      - bin/izonereport
+      - share/man
+
+    test:
+      commands:
+        - ienv


### PR DESCRIPTION
Add avrocpp 1.9.0
Add json 3.9.1
Add krb5 1.19.1
Add libarchive 3.5.1
Add nanodbc 2.13.0

The iRODS recipe builds three packages:

 irods-runtime (libraries)
 irods-dev (headers and libraries, depends on irods-runtime)
 irods-icommands (clients, depends on irods-runtime)

The strategy used is to prevent the build using hard-coded places for
tools or dependencies i.e. irods/externals, which would prevent us
from using the existing Conda tools to build a portable package.

By adding CMake install targets for the development headers and
libraries, we can install libraries, headers and executables directly
into the Conda build $PREFIX path. Conda then does the work of
creating packages, without the need for us to write custom tools. The
CPack outputs are still created by the build, but are discarded.

The supporting recipes for the necessary dependencies allow us to
avoid using the conda-forge channel at deployment time. The packages
depend only on the Anaconda defaults channel and our own
packages. This helps us to avoid the slow dependency solving that
Conda is known for.

The conda-forge channel is required at build time because we obtain
Clang from it. Ideally, we would use Conda's GCC to build, but that
would require more extensive modification of the CMake configuration.