### PR TITLE
Delete branch after creating merge request during mirroring

### DIFF
--- a/scripts/mirror_repo.sh
+++ b/scripts/mirror_repo.sh
@@ -132,6 +132,10 @@ do
              } "\
              "https://gitlab.internal.sanger.ac.uk/api/v4/projects/${project_id}/merge_requests"
     fi
+
+    # remove branch to prevent updates or similarly named branches from causing errors
+    git branch -D "$branch"
+
 done
 
 #Check for old mrs in gl


### PR DESCRIPTION
 Prevents force-pushed updates or similarly named future branches from breaking automation