### PR TITLE
Add simple integration test to build automation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,10 @@ variables:
   DEVEL_CHANNEL_DIR: /tmp/devel/generic/
   DEVEL_BUILD_DIR: /tmp/conda_artefacts/devel
   DEVEL_COMPARE_BRANCH: master
+  #
+  # TEST
+  #
+  PROD_WSI_CONDA_CHANNEL: https://dnap.cog.sanger.ac.uk/npg/conda/prod/generic
 
 include:
   - .gitlab_include/mirror.yml

--- a/.gitlab_include/devel_commit.yml
+++ b/.gitlab_include/devel_commit.yml
@@ -38,7 +38,7 @@ test_devel:
     - echo "Testing devel packages"
     - . /tmp/miniconda/etc/profile.d/conda.sh
     - conda activate base
-    - scripts/gitlab_test.sh "$DEVEL_CHANNEL_DIR"
+    - scripts/gitlab_test.sh "$DEVEL_CHANNEL_DIR" "$DEVEL_COMPARE_BRANCH"
   only:
     - devel
   except:

--- a/.gitlab_include/devel_commit.yml
+++ b/.gitlab_include/devel_commit.yml
@@ -32,3 +32,14 @@ deploy_devel:
   except:
     - schedules
 
+test_devel:
+  stage: test
+  script:
+    - echo "Testing devel packages"
+    - . /tmp/miniconda/etc/profile.d/conda.sh
+    - conda activate base
+    - scripts/gitlab_test.sh "$DEVEL_CHANNEL_DIR"
+  only:
+    - devel
+  except:
+    - schedules

--- a/.gitlab_include/merge_requests.yml
+++ b/.gitlab_include/merge_requests.yml
@@ -35,3 +35,4 @@ test_merge:
     - scripts/gitlab_test.sh "$PRE_DEVEL_CHANNEL_DIR" "$PRE_DEVEL_COMPARE_BRANCH"
   only:
     - merge_requests
+

--- a/.gitlab_include/merge_requests.yml
+++ b/.gitlab_include/merge_requests.yml
@@ -26,3 +26,12 @@ deploy_merge:
   only:
     - merge_requests
 
+test_merge:
+  stage: test
+  script:
+    - echo "Testing merge request packages"
+    - . /tmp/miniconda/etc/profile.d/conda.sh
+    - conda activate base
+    - scripts/gitlab_test.sh "$PRE_DEVEL_CHANNEL_DIR"
+  only:
+    - merge_requests

--- a/.gitlab_include/merge_requests.yml
+++ b/.gitlab_include/merge_requests.yml
@@ -32,6 +32,6 @@ test_merge:
     - echo "Testing merge request packages"
     - . /tmp/miniconda/etc/profile.d/conda.sh
     - conda activate base
-    - scripts/gitlab_test.sh "$PRE_DEVEL_CHANNEL_DIR"
+    - scripts/gitlab_test.sh "$PRE_DEVEL_CHANNEL_DIR" "$PRE_DEVEL_COMPARE_BRANCH"
   only:
     - merge_requests

--- a/scripts/gitlab_test.sh
+++ b/scripts/gitlab_test.sh
@@ -1,0 +1,39 @@
+#! /bin/bash
+
+set -e -u -x
+
+IFS=$'\n'
+for pkg in $(conda search --quiet -c file://$1 --override-channels | cut -f 1,2 -d ' ' | sed -E 's/[[:space:]]+/ /g') # $CHANNEL_DIR
+do
+    if [ "$pkg" == 'Loading channels:' ] || [ "$pkg" == '# Name' ]
+    then
+        continue
+    fi
+    
+    unset IFS
+    pkg=($pkg)
+    conda create -y -n ${pkg[0]} -c file://$1 ${pkg[0]}=${pkg[1]}
+    conda activate ${pkg[0]}
+    conda env export
+    echo "CHECKSUM = $(conda env export | md5sum)"
+    if [[ -f $CONDA_DIR/pkgs/${pkg[0]}-${pkg[1]}*/info/test/run_test.* ]] # some packages do not have tests, e.g. irods-runtime
+    then
+        test=$(ls $CONDA_DIR/pkgs/${pkg{[0]}-${pkg[1]}*/info/test/run_test.*)
+        case "$test" in
+            [*.sh])
+                bash "$test"
+                ;;
+            [*.py])
+                python "$test"
+                ;;
+            [*.pl])
+                perl "$test"
+                ;;
+        esac
+    fi
+    conda deactivate
+    conda remove -y -n ${pkg{[0]} --all
+done
+
+unset IFS
+

--- a/scripts/gitlab_test.sh
+++ b/scripts/gitlab_test.sh
@@ -2,38 +2,60 @@
 
 set -e -u -x
 
-IFS=$'\n'
-for pkg in $(conda search --quiet -c file://$1 --override-channels | cut -f 1,2 -d ' ' | sed -E 's/[[:space:]]+/ /g') # $CHANNEL_DIR
-do
-    if [ "$pkg" == 'Loading channels:' ] || [ "$pkg" == '# Name' ]
-    then
-        continue
-    fi
-    
-    unset IFS
-    pkg=($pkg)
-    conda create -y -n ${pkg[0]} -c file://$1 ${pkg[0]}=${pkg[1]}
-    conda activate ${pkg[0]}
-    conda env export
-    echo "CHECKSUM = $(conda env export | md5sum)"
-    if [[ -f $CONDA_DIR/pkgs/${pkg[0]}-${pkg[1]}*/info/test/run_test.* ]] # some packages do not have tests, e.g. irods-runtime
-    then
-        test=$(ls $CONDA_DIR/pkgs/${pkg{[0]}-${pkg[1]}*/info/test/run_test.*)
-        case "$test" in
-            [*.sh])
-                bash "$test"
-                ;;
-            [*.py])
-                python "$test"
-                ;;
-            [*.pl])
-                perl "$test"
-                ;;
-        esac
-    fi
+cleanup_env() {
     conda deactivate
-    conda remove -y -n ${pkg{[0]} --all
+    conda remove -n $1 --all # pkg[0]
+}
+
+check_package_in_channel() {
+    
+    if [[ "$1" =~  (^|[[:space:]])"$pkg"([[:space:]]|$) ]]   # channel_list (prod, devel or local)
+    then
+        IFS=' ' pkg=($pkg)
+        (conda create -y -n ${pkg[0]} -c file://$CHANNEL_DIR ${changed[0]}==${changed[1]} &&# argument 1 from script arguments
+             conda activate ${pkg[0]} &&
+             conda install -c $2 ${pkg[0]}=${pkg[1]} &&#CONDA_CHANNEL
+             conda env export &&
+             echo "CHECKSUM = $(conda env export | md5sum)") || (echo "installation fail" && return 1)
+        if [[ -f $CONDA_DIR/pkgs/${pkg[0]}-${pkg[1]}*/info/test/run_test.* ]] # some packages do not have tests, e.g. irods-runtime
+        then
+            test=$(ls $CONDA_DIR/pkgs/${pkg[0]}-${pkg[1]}*/info/test/run_test.*)
+            case "$test" in
+                [*.sh])
+                    bash "$test" || (cleanup_env "${pkg[0]}" && echo "test fail" && return 2)
+                    ;;
+                [*.py])
+                    python "$test" || (cleanup_env "${pkg[0]}" && echo "test fail" && return 2)
+                    ;;
+                [*.pl])
+                    perl "$test" || (cleanup_env "${pkg[0]}" && echo "test fail" && return 2)
+                    ;;
+            esac
+        fi
+        cleanup_env "${pkg[0]}"
+    else
+        echo "not in channel"
+        return 3
+    fi
+    return 0
+}
+
+CHANNEL_DIR=$1
+IFS=$'\n'
+prod=$(conda search --quiet -c $PROD_WSI_CONDA_CHANNEL --override-channels | sed -E 's/[[:space:]]+/ /g' | cut -f 1,2 -d' ')
+devel=$(conda search --quiet -c $WSI_CONDA_CHANNEL --override-channels | sed -E 's/[[:space:]]+/ /g' | cut -f 1,2 -d' ')
+local=$(conda search --quiet -c file://$CHANNEL_DIR --override-channels | sed -E 's/[[:space:]]+/ /g' | cut -f 1,2 -d ' ') 
+
+for changed in $(tools/bin/recipebook --changes origin/$2) # COMPARE_BRANCH
+do
+    IFS=' ' changed=($changed)
+    for pkg in $(tools/bin/recipebook --package ${changed[0]} --version ${changed[1]} --provides)
+    do
+
+        check_package_in_channel "$prod" "$PROD_WSI_CONDA_CHANNEL" ||
+            check_package_in_channel "$devel" "$WSI_CONDA_CHANNEL" ||
+            check_package_in_channel "$local" "file://$CHANNEL_DIR"
+    done
 done
 
-unset IFS
 


### PR DESCRIPTION
Installs each package (with automatically pulled dependencies) in a new environment, and runs the same tests that are run at build time (mostly -h or --version for executables) to check for incompatible dependency versions. 