### PR TITLE
Fix dependency declarations in the recipe metadata

### DIFF
--- a/red-recipes/irods/4.2.7/meta.yaml
+++ b/red-recipes/irods/4.2.7/meta.yaml
@@ -11,7 +11,7 @@ about:
   summary: "Open Source Data Management Software."
 
 build:
-  number: 11
+  number: 12
 
 source:
   - git_url: https://github.com/irods/irods.git
@@ -36,12 +36,12 @@ requirements:
     - make
     - help2man
   host:
-    - avrocpp-dev
+    - avrocpp-dev <1.9
     - libboost-dev
     - catch2
     - cppzmq
     - krb5-dev
-    - libarchive
+    - libarchive-dev
     - libjansson-dev
     - libpam-dev
     - libssl-dev
@@ -54,9 +54,9 @@ outputs:
     version: {{ version }}
     requirements:
       run:
-        - libavrocpp
+        - libavrocpp <1.9
         - libboost
-#       - krb5  # Avoids pulling in zlib from defaults
+        - libkrb5
         - libarchive
         - libjansson
         - libpam


### PR DESCRIPTION
Limit to avrocpp <1.9 because 1.9 contains a breaking API change in
code used by iRODS.

Add missing declarations that libarchive-dev is required for building.