### PR TITLE
Fix dependency declarations in iRODS 4.2.8 recipe metadata

### DIFF
--- a/red-recipes/irods/4.2.8/meta.yaml
+++ b/red-recipes/irods/4.2.8/meta.yaml
@@ -11,7 +11,7 @@ about:
   summary: "Open Source Data Management Software."
 
 build:
-  number: 17
+  number: 18
 
 source:
   - git_url: https://github.com/irods/irods.git
@@ -35,7 +35,7 @@ requirements:
     - make
     - help2man
   host:
-    - avrocpp-dev
+    - avrocpp-dev >=1.9
     - catch2
     - cppzmq
     - fmt
@@ -57,7 +57,7 @@ outputs:
       run:
         - fmt
         - libarchive
-        - libavrocpp
+        - libavrocpp >=1.9
         - libboost
         - libjansson
         - libkrb5
@@ -95,7 +95,7 @@ outputs:
         - {{ pin_subpackage("irods-runtime", exact=True) }}
         - fmt
         - libarchive
-        - libavrocpp
+        - libavrocpp >=1.9
         - libboost
         - libjansson
         - libkrb5


### PR DESCRIPTION
Limit to avrocpp >=1.9 because 1.9 contains a breaking API change in code used by iRODS.