### PR TITLE
ABI lib deps

### DIFF
--- a/recipes/zlib/1.2.11/meta.yaml
+++ b/recipes/zlib/1.2.11/meta.yaml
@@ -1,4 +1,5 @@
 {% set version = "1.2.11" %}
+{% set abi_version = "1" %}
 {% set sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1" %}
 
 package:
@@ -11,7 +12,9 @@ about:
   summary: A Massively Spiffy Yet Delicately Unobtrusive Compression Library.
 
 build:
-  number: 2
+  number: 3
+  ignore_run_exports_from:  # avoid the automatic libgcc-ng dependancy which is incorrect?
+    - {{ compiler('c') }}
 
 source:
   url: https://sourceforge.net/projects/libpng/files/zlib/{{ version }}/zlib-{{ version }}.tar.gz/download
@@ -22,25 +25,37 @@ requirements:
   build:
     - {{ compiler("c") }}
     - make
+  run:
+    - {{ pin_subpackage("libz-dev", exact=True) }}
+    - {{ pin_subpackage("libz" + abi_version, exact=True) }}
 
 outputs:
-  - name: libz
+  - name: libz  # this is the package name to be used in host dependency of package dependent on zlib (hope to avoid need for ABI including package name in downstream recipe)
     version: {{ version }}
+    run_exports: # automatic propagation of appropriate run dependency to created dependent package
+      - {{ pin_subpackage("libz" + abi_version, max_pin='x') }}
     requirements:
-      build:
-        - {{ compiler("c") }}
-        - make
+      run:
+        - {{ pin_subpackage("libz" + abi_version, exact=True) }}
+
+
+  - name: "libz{{ abi_version }}" # ABI including package name - to allow for differing ABI versions simultatneously installed
+    version: {{ version }}
+    run_exports:
+      - {{ pin_subpackage("libz" + abi_version, max_pin='x') }}
     files:
       - lib/libz.so*
     test:
       commands:
         - test -h ${PREFIX}/lib/libz.so
+        - test -h "${PREFIX}/lib/libz.so.{{ abi_version }}"
+        - test -f "${PREFIX}/lib/libz.so.{{ abi_version }}."*
 
   - name: libz-dev
     version: {{ version }}
     requirements:
-      run:
-        - {{ pin_subpackage('libz', exact=True) }}
+      run_constrained:
+        - {{ pin_subpackage("libz" + abi_version, exact=True) }}
     files:
       - include
       - lib/libz.a


### PR DESCRIPTION
@kjsanger @mksanger 
Possible way of dealing with ABI dependencies explicitly - just zlib here - we'd need to adapt other lib recipes and ensure tools used the (non-version name) lib dependency in their host dep. Note, the way it's done you _might_ be able to skip the dep in the host dependency to get static lib compilation for the tool - but that would be a (bonus flexibility) side-effect ...