### PR TITLE
Fix gitlab integration tests

### DIFF
--- a/tools/bin/recipebook
+++ b/tools/bin/recipebook
@@ -73,7 +73,7 @@ parser.add_argument("-v", "--version", type=str,
                          "Required by --provides and -p/--package.")
 parser.add_argument("-c", "--changes", type=str,
                     help="Report only on recipes that have changed "
-                         "relative to another branch (defaults to 'master'")
+                         "relative to another branch (defaults to 'master')")
 parser.add_argument("--provides",
                     help="When reporting dependency relationships with "
                          "-p|--package and -v|--version, report the packages "
@@ -81,6 +81,9 @@ parser.add_argument("--provides",
                          "i.e. those that are dependencies of the package, "
                          "rather than those it depends on."
                          "Requires -p/--package and -v/--version.",
+                    action="store_true")
+parser.add_argument("--sub-package",
+                    help="Report sub-package names instead of package names.",
                     action="store_true")
 
 parser.add_argument("--debug",
@@ -111,9 +114,9 @@ def main():
         nv = (args.package, parse(args.version))
         if nv in recipe_book.dependency_graph():
             if args.provides:
-                recipe_book.print_descendants(nv)
+                recipe_book.print_descendants(nv, args.sub_package)
             else:
-                recipe_book.print_ancestors(nv)
+                recipe_book.print_ancestors(nv, args.sub_package)
         else:
             raise ValueError("Package {} version {} is not present "
                              "in the graph".format(nv[0], nv[1]))
@@ -121,10 +124,10 @@ def main():
         # Print a unified list of all changed recipes
         changed_recipes = find_changed_recipe_files(root, args.changes)
         recipe_book = RecipeBook(changed_recipes)
-        recipe_book.print_graph()
+        recipe_book.print_graph(args.sub_package)
     else:
         # Print everything
-        recipe_book.print_graph()
+        recipe_book.print_graph(args.sub_package)
 
 
 if __name__ == "__main__":

--- a/tools/recipebook/recipebook.py
+++ b/tools/recipebook/recipebook.py
@@ -274,37 +274,47 @@ class RecipeBook(object):
         g = self.dependency_graph()
         return nx.subgraph(g, nx.ancestors(g, nv))
 
-    def print_graph(self):
+    def print_graph(self, subpackage: bool):
         """Prints the entire package graph in topological sort order.
+        Prints sub-packages instead of packages if subpackage is True.
 
+        Args:
+            subpackage: print subpackages if true
         """
-        self.__print_subgraph(self.dependency_graph())
+        self.__print_subgraph(self.dependency_graph(), subpackage)
 
-    def print_descendants(self, nv: Tuple[str, Version]):
-        """Prints a sub-graph of packages that depend on the named package
-        version.
+    def print_descendants(self, nv: Tuple[str, Version], subpackage: bool):
+        """Prints a sub-graph of packages or sub-packages that depend on the
+        named package version.
 
         Args:
             nv: package name, version tuple
+            subpackage: print subpackages if True
         """
-        self.__print_subgraph(self.package_descendants(nv))
+        self.__print_subgraph(self.package_descendants(nv), subpackage)
 
-    def print_ancestors(self, nv: Tuple[str, Version]):
-        """Prints a sub-graph of packages on which the named package version
-        depends.
+    def print_ancestors(self, nv: Tuple[str, Version], subpackage: bool):
+        """Prints a sub-graph of packages or sub-packages on which the named
+        package version depends.
 
         Args:
-        nv: package name, version tuple
+            nv: package name, version tuple
+            subpackage: print subpackages if True
         """
-        self.__print_subgraph(self.package_ancestors(nv))
+        self.__print_subgraph(self.package_ancestors(nv), subpackage)
 
-    def print_package(self, nv: Tuple[str, Version]):
+    def print_package(self, nv: Tuple[str, Version], subpackage: bool):
         if self.__is_root_node(nv):
             return
 
         if nv in self.pkg_recipes:
             (name, version) = nv
-            print(name, version, os.path.dirname(self.package_recipe(nv)))
+            if subpackage:
+                for sub, parent in self.pkg_parent.items():
+                    if parent == name:
+                        print(sub, version, os.path.dirname(self.package_recipe(nv)))
+            else:
+                print(name, version, os.path.dirname(self.package_recipe(nv)))
         else:
             raise ValueError("RecipeBook does not contain {}".format(nv))
 
@@ -362,9 +372,9 @@ class RecipeBook(object):
                     graph.add_edge(nv, self.graph_root)
         return graph
 
-    def __print_subgraph(self, graph):
+    def __print_subgraph(self, graph, subpackage: bool):
         for node in nx.topological_sort(graph):
-            self.print_package(node)
+            self.print_package(node, subpackage)
 
     @staticmethod
     def __is_root_node(node: Tuple[str, Version]):


### PR DESCRIPTION
 - Add `--sub-package` option to recipebook
 - Use `recipebook --sub-package` to get correct install targets
 - Use `ldd` to test for fallback to system libraries