### PR TITLE
Fix integration tests

### DIFF
--- a/.gitlab_include/devel_commit.yml
+++ b/.gitlab_include/devel_commit.yml
@@ -38,7 +38,7 @@ test_devel:
     - echo "Testing devel packages"
     - . /tmp/miniconda/etc/profile.d/conda.sh
     - conda activate base
-    - scripts/gitlab_test.sh "$DEVEL_CHANNEL_DIR" "$DEVEL_COMPARE_BRANCH"
+    - bash -i scripts/gitlab_test.sh "$DEVEL_CHANNEL_DIR" "$DEVEL_COMPARE_BRANCH"
   only:
     - devel
   except:

--- a/.gitlab_include/merge_requests.yml
+++ b/.gitlab_include/merge_requests.yml
@@ -32,7 +32,7 @@ test_merge:
     - echo "Testing merge request packages"
     - . /tmp/miniconda/etc/profile.d/conda.sh
     - conda activate base
-    - scripts/gitlab_test.sh "$PRE_DEVEL_CHANNEL_DIR" "$PRE_DEVEL_COMPARE_BRANCH"
+    - bash -i scripts/gitlab_test.sh "$PRE_DEVEL_CHANNEL_DIR" "$PRE_DEVEL_COMPARE_BRANCH"
   only:
     - merge_requests
 

--- a/scripts/gitlab_test.sh
+++ b/scripts/gitlab_test.sh
@@ -13,7 +13,7 @@
 . $CONDA_DIR/etc/profile.d/conda.sh
 
 # CONSTANTS
-set -e -u -x
+set -e -u
 IFS=$'\n'
 
 CHANNEL_DIR=$1
@@ -56,18 +56,18 @@ check_package_in_channel() {
 
     if [[ "$1" =~  (^|[[:space:]])"$pkg"([[:space:]]|$) ]] || [[ "$(echo $1 | sed 's/\_/\./g')" =~  (^|[[:space:]])"$pkg"([[:space:]]|$) ]]
     then
-        IFS=' ' read -r -a pkg <<< "$pkg"
+        IFS=' ' read -r -a package <<< "$pkg"
         # install dependency from the local channel and package from
         # selected channel
         (conda create -y -n "test_env" -c file://$CHANNEL_DIR -c $WSI_CONDA_CHANNEL -c pkgs/main --override-channels ${sub[@]} &&
              conda activate "test_env" &&
-             conda install -y -c $2 ${pkg[0]}=${pkg[1]} &&
+             conda install -y -c $2 ${package[0]}=${package[1]} &&
              conda env export &&
              echo "CHECKSUM = $(conda env export | md5sum)")||
             (cleanup_env && echo "installation fail" && return 1)
         # Find and run conda tests -
         #     some packages do not have tests, e.g. irods-runtime
-        pkg_dir=$(ls -d -1 $CONDA_DIR/pkgs/${pkg[0]}-${pkg[1]}* | head -n1)
+        pkg_dir=$(ls -d -1 $CONDA_DIR/pkgs/${package[0]}-${package[1]}* | head -n1)
         pkg_test=$(ls $pkg_dir/info/test/run_test.*)
         if [[ -f $pkg_test ]] 
         then
@@ -100,7 +100,7 @@ check_package_in_channel() {
         
         cleanup_env
     else
-        echo "not in channel"
+        echo "$pkg not in channel"
         if [ $is_root -eq 1 ]
         then
             echo "but is a root package, so may have sub packages"

--- a/scripts/gitlab_test.sh
+++ b/scripts/gitlab_test.sh
@@ -10,7 +10,7 @@
 #     $1 - CHANNEL_DIR (explicit for global scope)
 #     $2 - COMPARE_BRANCH 
 
-
+. $CONDA_DIR/etc/profile.d/conda.sh
 
 # CONSTANTS
 set -e -u -x
@@ -22,15 +22,13 @@ prod=$(conda search --quiet -c "$PROD_WSI_CONDA_CHANNEL" --override-channels | s
 devel=$(conda search --quiet -c "$WSI_CONDA_CHANNEL" --override-channels | sed -E 's/[[:space:]]+/ /g' | cut -f 1,2 -d' ')
 local=$(conda search --quiet -c "file://$CHANNEL_DIR" --override-channels | sed -E 's/[[:space:]]+/ /g' | cut -f 1,2 -d ' ') 
 
-
-
 #FUNCTIONS
 
 cleanup_env() {
     # Removes the testing environment
     
     conda deactivate
-    conda remove -n "test_env" --all
+    conda remove -y -n "test_env" --all
 }
 
 check_package_in_channel() {
@@ -40,69 +38,118 @@ check_package_in_channel() {
     # - Creates a test environment containing the newly built package
     # - Installs the dependent package from the provided channel
     # - Finds and runs the conda run_test.* script
+    # - Checks for system versions of the libraries that should by provided by
+    #   subpackages
     #
     # Args:
     #     $1 - list of packages in a channel (prod, devel or local, defined below)
     #     $2 - conda channel path
-    
-    if [[ "$1" =~  (^|[[:space:]])"$pkg"([[:space:]]|$) ]]
+
+    is_root=0
+    if [[ "$pkg" =~ "root " ]]
+    then
+        pkg=$(echo "$pkg" | cut -f 2,3 -d ' ')
+        is_root=1
+    else
+        pkg=$(echo "$pkg" | cut -f 1,2 -d ' ')
+    fi
+
+    if [[ "$1" =~  (^|[[:space:]])"$pkg"([[:space:]]|$) ]] || [[ "$(echo $1 | sed 's/\_/\./g')" =~  (^|[[:space:]])"$pkg"([[:space:]]|$) ]]
     then
         IFS=' ' read -r -a pkg <<< "$pkg"
         # install dependency from the local channel and package from
         # selected channel
-        (conda create -y -n "test_env" -c file://$CHANNEL_DIR \
-               ${changed[0]}==${changed[1]} &&
+        (conda create -y -n "test_env" -c file://$CHANNEL_DIR -c $WSI_CONDA_CHANNEL -c pkgs/main --override-channels ${sub[@]} &&
              conda activate "test_env" &&
-             conda install -c $2 ${pkg[0]}=${pkg[1]} &&
+             conda install -y -c $2 ${pkg[0]}=${pkg[1]} &&
              conda env export &&
              echo "CHECKSUM = $(conda env export | md5sum)")||
             (cleanup_env && echo "installation fail" && return 1)
         # Find and run conda tests -
         #     some packages do not have tests, e.g. irods-runtime
-        if [[ -f $CONDA_DIR/pkgs/${pkg[0]}-${pkg[1]}*/info/test/run_test.* ]] 
+        pkg_dir=$(ls -d -1 $CONDA_DIR/pkgs/${pkg[0]}-${pkg[1]}* | head -n1)
+        pkg_test=$(ls $pkg_dir/info/test/run_test.*)
+        if [[ -f $pkg_test ]] 
         then
-            test=$(ls $CONDA_DIR/pkgs/${pkg[0]}-${pkg[1]}*/info/test/run_test.*)
-            case "$test" in
+            case "$pkg_test" in
                 [*.sh])
-                    bash "$test" || (cleanup_env && echo "test fail" && return 2)
+                    bash "$pkg_test" || (cleanup_env && echo "test fail" && return 2)
                     ;;
                 [*.py])
-                    python "$test" || (cleanup_env && echo "test fail" && return 2)
+                    python "$pkg_test" || (cleanup_env && echo "test fail" && return 2)
                     ;;
                 [*.pl])
-                    perl "$test" || (cleanup_env && echo "test fail" && return 2)
+                    perl "$pkg_test" || (cleanup_env && echo "test fail" && return 2)
                     ;;
             esac
         fi
 
-        ldd "$CONDA_DIR/envs/test_env/bin/*" | grep ${changed[0]} | grep "/usr/lib/" &&
-            (cleanup_env && echo "system version of ${changed[0]} used" && return 3)
+        for subpackage in ${sub[@]}
+        do
+            for executable in $(ls "$CONDA_DIR/envs/test_env/bin")
+            do
+                ldd $CONDA_DIR/envs/test_env/bin/$executable | grep $subpackage | grep "/usr/lib/" &&
+                    (cleanup_env && echo "system version of ${changed[0]} used" && return 3)
+            done
+            for library in $(ls "$CONDA_DIR/envs/test_env/lib")
+            do
+                ldd "$CONDA_DIR/envs/test_env/lib/$library" | grep $subpackage | grep "/usr/lib/" &&
+                    (cleanup_env && echo "system version of ${changed[0]} used" && return 3)
+            done
+        done
         
-        ldd "$CONDA_DIR/envs/test_env/lib/*" | grep ${changed[0]} | grep "/usr/lib/" &&
-            (cleanup_env && echo "system version of ${changed[0]} used" && return 3)
-
         cleanup_env
     else
         echo "not in channel"
-        return 4
+        if [ $is_root -eq 1 ]
+        then
+            echo "but is a root package, so may have sub packages"
+        else
+            return 4
+        fi
     fi
     return 0
 }
 
+test_previous_root() {
+
+    # called once subpackages of the previous root have been gathered, runs tests
+
+    if [[ -n $root ]]
+    then
+        if [[ -z $sub ]]
+        then
+            sub=(${root[0]}=${root[1]})
+        fi
+        # ensure that the base env is activated
+        conda activate
+        for pkg in $(tools/bin/recipebook --package ${root[0]} --version ${root[1]} --provides --grouped-packages)
+        do
+            check_package_in_channel "$prod" "$PROD_WSI_CONDA_CHANNEL" ||
+                check_package_in_channel "$devel" "$WSI_CONDA_CHANNEL" ||
+                check_package_in_channel "$local" "file://$CHANNEL_DIR"
+        done
+    fi
+}
 
 
 # LOOP
-
-for changed in $(tools/bin/recipebook --changes origin/$2 --sub-package)
+root=''
+sub=''
+for changed in $(tools/bin/recipebook --changes origin/$2 --grouped-packages)
 do
     IFS=' ' read -r -a changed <<< "$changed"
-    for pkg in $(tools/bin/recipebook --package ${changed[0]} --version ${changed[1]} --provides --output-packages)
-    do
-        check_package_in_channel "$prod" "$PROD_WSI_CONDA_CHANNEL" ||
-            check_package_in_channel "$devel" "$WSI_CONDA_CHANNEL" ||
-            check_package_in_channel "$local" "file://$CHANNEL_DIR"
-    done
+    if [ ${changed[0]} == "root" ]
+    then
+        test_previous_root
+        root=(${changed[1]} ${changed[2]})
+        sub=''
+    else
+        sub=($sub ${changed[0]}=${changed[1]})
+    fi
 done
+
+test_previous_root
 
 unset IFS
 

--- a/scripts/gitlab_test.sh
+++ b/scripts/gitlab_test.sh
@@ -47,7 +47,7 @@ check_package_in_channel() {
     
     if [[ "$1" =~  (^|[[:space:]])"$pkg"([[:space:]]|$) ]]
     then
-        IFS=' ' pkg=($pkg)
+        IFS=' ' read -r -a pkg <<< "$pkg"
         # install dependency from the local channel and package from
         # selected channel
         (conda create -y -n "test_env" -c file://$CHANNEL_DIR \
@@ -95,7 +95,7 @@ check_package_in_channel() {
 
 for changed in $(tools/bin/recipebook --changes origin/$2 --sub-package)
 do
-    IFS=' ' changed=($changed)
+    IFS=' ' read -r -a changed <<< "$changed"
     for pkg in $(tools/bin/recipebook --package ${changed[0]} --version ${changed[1]} --provides --output-packages)
     do
         check_package_in_channel "$prod" "$PROD_WSI_CONDA_CHANNEL" ||

--- a/tools/bin/recipebook
+++ b/tools/bin/recipebook
@@ -84,12 +84,11 @@ parser.add_argument("--provides",
 level_group = parser.add_mutually_exclusive_group()
 level_group.add_argument("--sub-packages",
                          help="Report only sub-package names instead of root "
-                              "package names. Excludes --output-packages.",
+                              "package names. Excludes --grouped-packages.",
                          action="store_true")
-level_group.add_argument("--output-packages",
-                         help="Report package names that match outputs of "
-                              "build, i.e. sub-package names if present and "
-                              "root package names if not. Excludes --sub-packages.",
+level_group.add_argument("--grouped-packages",
+                         help="Report root package names followed by their "
+                              "group of sub-packages. Excludes --sub-packages",
                          action="store_true")
 
 parser.add_argument("--debug",
@@ -111,8 +110,8 @@ log.basicConfig(level=log_level)
 package_level = PrintLevel.ROOT
 if args.sub_packages:
     package_level = PrintLevel.SUB
-elif args.output_packages:
-    package_level = PrintLevel.OUT
+elif args.grouped_packages:
+    package_level = PrintLevel.GROUPED
 
 args = parser.parse_args()
 

--- a/tools/recipebook/recipebook.py
+++ b/tools/recipebook/recipebook.py
@@ -58,7 +58,7 @@ class RecipeBook(object):
     pkg_recipes: Dict[Tuple, str]
     pkg_versions: Dict[str, List[Version]]
     pkg_requirements: Dict[Tuple, List[Tuple]]
-    pkg_parent: Dict[str, str]
+    pkg_parent: Dict[str, List]
 
     def __init__(self, recipe_files: List[str]):
         self.graph_root = (None, None)
@@ -122,7 +122,10 @@ class RecipeBook(object):
         outputs = recipe.get(OUTPUTS, [])
         for output in outputs:
             output_name = output[NAME]
-            self.pkg_parent[output_name] = pkg_name
+            try:
+                self.pkg_parent[output_name].append(pkg_version)
+            except KeyError:
+                self.pkg_parent[output_name] = [pkg_name, pkg_version]
             output_reqs = output.get(REQUIREMENTS, {})
 
             pkg_reqs += output_reqs.get(HOST, [])
@@ -253,7 +256,7 @@ class RecipeBook(object):
         Returns: str
 
         """
-        return self.pkg_parent[name]
+        return self.pkg_parent[name][0]
 
     def package_descendants(self, nv: Tuple[str, Version]) -> nx.DiGraph:
         """Returns a graph of all the packages that depend on the named
@@ -331,13 +334,13 @@ class RecipeBook(object):
         if nv in self.pkg_recipes:
             (name, version) = nv
             for sub, parent in self.pkg_parent.items():
-                if parent == name:
+                if parent[0] == name and version in parent:
                     print(sub, version, os.path.dirname(self.package_recipe(nv)))
         else:
             raise ValueError("RecipeBook does not contain {}".format(nv))
 
     def _has_subpackages(self, name) -> bool:
-        if name in self.pkg_parent.values():
+        if name in [package[0] for package in self.pkg_parent.values()]:
             return True
         else:
             return False
@@ -395,7 +398,7 @@ class RecipeBook(object):
                             if req_pkg in self.pkg_parent:
                                 # Require the parent package rather than
                                 # the sub-package
-                                parent_pkg = self.pkg_parent[req_pkg]
+                                parent_pkg = self.package_parent(req_pkg)
                                 num_reqs_located += add_edge(parent_pkg, spec)
                             else:
                                 log.warning("Can't find required package %s",

--- a/tools/recipebook/recipebook.py
+++ b/tools/recipebook/recipebook.py
@@ -42,7 +42,7 @@ VERSION = "version"
 class PrintLevel(Enum):
     ROOT = 0
     SUB = 1
-    OUT = 2
+    GROUPED = 2
 
 
 class RecipeBook(object):
@@ -343,17 +343,16 @@ class RecipeBook(object):
             return False
 
     def print_packages(self, nv: Tuple[str, Version]):
-        """Prints information that matches the output of conda build,
-        sub-packages if present, or root package if not.
+        """Prints root packages followed by their sub packages.
 
         Args:
             nv: package name, version tuple
         """
 
+        print("root", end=" ")
+        self.print_root_package(nv)
         if self._has_subpackages(nv[0]):
             self.print_sub_packages(nv)
-        else:
-            self.print_root_package(nv)
 
     def dependency_graph(self) -> nx.DiGraph:
         """
@@ -417,7 +416,7 @@ class RecipeBook(object):
                 self.print_root_package(node)
             elif level == PrintLevel.SUB:
                 self.print_sub_packages(node)
-            elif level == PrintLevel.OUT:
+            elif level == PrintLevel.GROUPED:
                 self.print_packages(node)
 
     @staticmethod


### PR DESCRIPTION
- Change recipebook `--output-package` to `--grouped-package` printing root
      package followed by any subpackages and use this to get correct package and
      subpackage names for use in `recipebook` and `conda install`
- Source `conda.sh` from within the script, and run script interactively to fix `conda activate` bug
- use `read` command instead of varible assignment when changing IFS is necessary
