### PR TITLE
Pin boost version consistently within recipes

### DIFF
--- a/recipes/avrocpp/1.8.2/meta.yaml
+++ b/recipes/avrocpp/1.8.2/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha1: {{ hash }}
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:
@@ -22,12 +22,12 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
-    - libboost-dev>={{ boost_version }}
+    - libboost-dev >={{ boost_version }}
     - liblzma-dev
     - libz-dev
     - snappy
   run:
-    - libboost
+    - libboost >={{ boost_version }}
     - liblzma
     - libz
     - snappy

--- a/recipes/avrocpp/1.9.0/meta.yaml
+++ b/recipes/avrocpp/1.9.0/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha1: {{ hash }}
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:
@@ -22,12 +22,12 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
-    - libboost-dev>={{ boost_version }}
+    - libboost-dev >={{ boost_version }}
     - liblzma-dev
     - libz-dev
     - snappy
   run:
-    - libboost
+    - libboost >={{ boost_version }}
     - liblzma
     - libz
     - snappy


### PR DESCRIPTION
A pining version is declared for some sub-packages, but not for others. These should be consistent to keep the production environment well defined.