### PR TITLE
Increase io_lib build number to allow new build to use updated gnutls

### DIFF
--- a/.gitlab_include/devel_commit.yml
+++ b/.gitlab_include/devel_commit.yml
@@ -38,7 +38,7 @@ test_devel:
     - echo "Testing devel packages"
     - . /tmp/miniconda/etc/profile.d/conda.sh
     - conda activate base
-    - bash -i scripts/gitlab_test.sh "$DEVEL_CHANNEL_DIR" "$DEVEL_COMPARE_BRANCH"
+    - bash -i scripts/gitlab_test.sh "$DEVEL_BUILD_DIR" "$DEVEL_COMPARE_BRANCH"
   only:
     - devel
   except:

--- a/.gitlab_include/merge_requests.yml
+++ b/.gitlab_include/merge_requests.yml
@@ -32,7 +32,7 @@ test_merge:
     - echo "Testing merge request packages"
     - . /tmp/miniconda/etc/profile.d/conda.sh
     - conda activate base
-    - bash -i scripts/gitlab_test.sh "$PRE_DEVEL_CHANNEL_DIR" "$PRE_DEVEL_COMPARE_BRANCH"
+    - bash -i scripts/gitlab_test.sh "$PRE_DEVEL_BUILD_DIR" "$PRE_DEVEL_COMPARE_BRANCH"
   only:
     - merge_requests
 

--- a/recipes/io_lib/1.14.11/meta.yaml
+++ b/recipes/io_lib/1.14.11/meta.yaml
@@ -11,7 +11,7 @@ about:
   summary: DNA sequence assembly, editing and analysis tools.
 
 build:
-  number: 3
+  number: 4
 
 source:
   url: https://github.com/jkbonfield/io_lib/releases/download/io_lib-1-14-11/io_lib-{{ version }}.tar.gz

--- a/scripts/gitlab_test.sh
+++ b/scripts/gitlab_test.sh
@@ -7,7 +7,7 @@
 # versions in other channels will also be successful.
 #
 # Command Line Arguments (pipeline dependent):
-#     $1 - CHANNEL_DIR (explicit for global scope)
+#     $1 - BUILD_DIR (explicit for global scope)
 #     $2 - COMPARE_BRANCH 
 
 . $CONDA_DIR/etc/profile.d/conda.sh
@@ -16,11 +16,11 @@
 set -e -u
 IFS=$'\n'
 
-CHANNEL_DIR=$1
+BUILD_DIR=$1
 
 prod=$(conda search --quiet -c "$PROD_WSI_CONDA_CHANNEL" --override-channels | sed -E 's/[[:space:]]+/ /g' | cut -f 1,2 -d' ')
 devel=$(conda search --quiet -c "$WSI_CONDA_CHANNEL" --override-channels | sed -E 's/[[:space:]]+/ /g' | cut -f 1,2 -d' ')
-local=$(conda search --quiet -c "file://$CHANNEL_DIR" --override-channels | sed -E 's/[[:space:]]+/ /g' | cut -f 1,2 -d ' ') 
+local=$(conda search --quiet -c "file://$BUILD_DIR" --override-channels | sed -E 's/[[:space:]]+/ /g' | cut -f 1,2 -d ' ') 
 
 #FUNCTIONS
 
@@ -59,7 +59,7 @@ check_package_in_channel() {
         IFS=' ' read -r -a package <<< "$pkg"
         # install dependency from the local channel and package from
         # selected channel
-        (conda create -y -n "test_env" -c file://$CHANNEL_DIR -c $WSI_CONDA_CHANNEL -c pkgs/main --override-channels ${sub[@]} &&
+        (conda create -y -n "test_env" -c file://$BUILD_DIR -c $WSI_CONDA_CHANNEL -c pkgs/main --override-channels ${sub[@]} &&
              conda activate "test_env" &&
              conda install -y -c $2 ${package[0]}=${package[1]} &&
              conda env export &&
@@ -127,7 +127,7 @@ test_previous_root() {
         do
             check_package_in_channel "$prod" "$PROD_WSI_CONDA_CHANNEL" ||
                 check_package_in_channel "$devel" "$WSI_CONDA_CHANNEL" ||
-                check_package_in_channel "$local" "file://$CHANNEL_DIR"
+                check_package_in_channel "$local" "file://$BUILD_DIR"
         done
     fi
 }


### PR DESCRIPTION
Also change from channel dir to build dir in tests to test new versions rather than those previously in the channel - this bug caused some further confusion while investigating.