### PR TITLE
Add --pull-build-image CLI option to the build script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+ - --pull-build-image CLI option for build script
+
+### Removed
+
+### Changed
+
+ - The default behaviour of the build script is no longer to pull the build
+image, but to expect to find it locally
+
+## [3.0.0]

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,0 @@
-
-ensure that libmaus2 and scramble are built with a particular version of libstaden-read. These versions need to match
-because "biobambam [...] won't work with modern io_lib's until it is updated to use the resized structure elements"
-(see https://github.com/samtools/samtools/issues/980). So currently (5Aug2019) biobambam2 2.0.79 requires
-libmaus2 2.0.420 which requires libstaden-read 1.14.9.

--- a/tools/bin/build
+++ b/tools/bin/build
@@ -83,6 +83,10 @@ parser.add_argument("--conda-build-image",
                     help="Docker image used to build packages, "
                     "defaults to {}".format(DEFAULT_BUILD_IMAGE),
                     type=str, nargs="?", default=DEFAULT_BUILD_IMAGE)
+parser.add_argument("--pull-build-image",
+                    help="Pull the Docker image used to build packages, "
+                    "defaults to false",
+                    action="store_true")
 parser.add_argument("--remove-container",
                     help="Remove the Docker container after each build",
                     action="store_true")
@@ -116,7 +120,8 @@ elif args.verbose or args.dry_run:
     level = log.INFO
 log.basicConfig(level=level)
 
-docker_pull(args.conda_build_image)
+if args.pull_build_image:
+    docker_pull(args.conda_build_image)
 
 fail = False
 


### PR DESCRIPTION
This changes the default behaviour from pulling the image to not pulling it. I've done this in the interest of CLI ergonomics i.e. it's better to issue an imperative --pull-build-image rather than a negation. It fits better with the style of the other options too.