### PR TITLE
Automation build changes for centos-7

### DIFF
--- a/scripts/gitlab_build.sh
+++ b/scripts/gitlab_build.sh
@@ -9,10 +9,5 @@ rsync -av $2 $3 # $CHANNEL_DIR $BUILD_DIR
 
 ./tools/bin/recipebook --changes origin/$1 recipes | ./tools/bin/build \
  --recipes-dir $CI_PROJECT_DIR --artefacts-dir $3 --conda-build-image $CONDA_IMAGE \
- --build-channel $WSI_CONDA_CHANNEL \
- --verbose --remove-container
-
-./tools/bin/recipebook --changes origin/$1 red-recipes | ./tools/bin/build \
- --recipes-dir $CI_PROJECT_DIR --artefacts-dir $3 --conda-build-image $CONDA_IMAGE \
- --build-channel $WSI_CONDA_CHANNEL conda-forge bioconda \
+ --build-channel $WSI_CONDA_CHANNEL --conda-uid 1001 --conda-gid 32001 \
  --verbose --remove-container


### PR DESCRIPTION
 - Set build image uid and gid to safe values for centos-7
 - Remove 'red-recipes' build line (clang is now in the channel)