### PR TITLE
Tophat 2.1.1 : patch for C++11 templating

### DIFF
--- a/recipes/tophat2/2.1.1/conda_build_config.yaml
+++ b/recipes/tophat2/2.1.1/conda_build_config.yaml
@@ -1,8 +1,8 @@
 c_compiler_version:
-  - 5.4
+  - 7.5
 
 cxx_compiler_version:
-  - 5.4
+  - 7.5
 
 CFLAGS: >-
   -O2

--- a/recipes/tophat2/2.1.1/cxx11template.patch
+++ b/recipes/tophat2/2.1.1/cxx11template.patch
@@ -1,0 +1,11 @@
+--- ../../tophat2_1627493902816/work/src/tophat_reports.cpp	2016-02-23 21:20:44.320710000 +0000
++++ ./src/tophat_reports.cpp	2021-07-29 08:46:23.018409815 +0000
+@@ -2705,7 +2705,7 @@
+ 				junction_stat.gtf_match = true;
+ 				junction_stat.accepted = true;
+ 
+-				gtf_junctions.insert(make_pair<Junction, JunctionStats>(Junction(ref_id, left_coord, right_coord, antisense), junction_stat));
++				gtf_junctions.insert(make_pair(Junction(ref_id, left_coord, right_coord, antisense), junction_stat));
+ 			}
+ 		}
+ 		fprintf(stderr, "Loaded %d GFF junctions from %s.\n", (int)(gtf_junctions.size()), gtf_juncs.c_str());

--- a/recipes/tophat2/2.1.1/meta.yaml
+++ b/recipes/tophat2/2.1.1/meta.yaml
@@ -11,12 +11,14 @@ about:
   summary: Spliced read mapper for RNA-Seq.
 
 build:
-  number: 2
+  number: 3
   
 source:
   url: http://ccb.jhu.edu/software/tophat/downloads/tophat-{{ version }}.tar.gz
   fn: tophat2-{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    - cxx11template.patch
 
 requirements:
   build:


### PR DESCRIPTION
Allows use of later base Conda compiler which has correct deps for
libraries.

Keeps this last version of Tophat available whilst we should
direct such analysis to a more contemporary tool e.g. HISAT2