### PR TITLE
Fix rsync `Operation not permitted` errors due to setting groups, times, etc.

### DIFF
--- a/tools/automation/gitlab_build.sh
+++ b/tools/automation/gitlab_build.sh
@@ -5,7 +5,7 @@ set -e -u -x
 git fetch origin $1 # $COMPARE_BRANCH
 
 
-rsync -av $2 $3 # $CHANNEL_DIR $BUILD_DIR
+rsync -rlv $2 $3 # $CHANNEL_DIR $BUILD_DIR
 
 ./tools/bin/recipebook --changes origin/$1 recipes | ./tools/bin/build \
  --recipes-dir $CI_PROJECT_DIR --artefacts-dir $3 --conda-build-image $CONDA_IMAGE \

--- a/tools/automation/gitlab_deploy.sh
+++ b/tools/automation/gitlab_deploy.sh
@@ -2,7 +2,7 @@
 
 set -e -u -x
 
-rsync -av --include='*.tar.bz2' --exclude='*' $1/linux-64/ $2/linux-64/ # $BUILD_DIR $CHANNEL_DIR 
+rsync -rlv --include='*.tar.bz2' --exclude='*' $1/linux-64/ $2/linux-64/ # $BUILD_DIR $CHANNEL_DIR
 
 conda index $2 # $CHANNEL_DIR
 


### PR DESCRIPTION
The change to centOS required the group and user ids used by the docker image to be changed, which meant that identical files with different permissions were being synced using rsync, causing errors (I think).