### PR TITLE
Prevent false successes in actions workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: "Build recipes"
         run: |
+          set -o pipefail
+
           mkdir -p "$GITHUB_WORKSPACE/conda-artefacts/linux-64"
           while sleep 300; do echo $SECONDS sec elapsed, still building ... ; done &
 


### PR DESCRIPTION
Separate running recipebook from running build in github actions so that if recipebook fails, it will make the workflow fail ~and change loop of build script so that it fails if no stdin is provided~.

This is necessary for situations like https://github.com/wtsi-npg/npg_conda/pull/272/checks, where recipebook failed due to pip installing an old version of conda, but actions reported success.