### PR TITLE
Delete cache files after indexing conda channel for upload during automation

### DIFF
--- a/tools/automation/gitlab_deploy.sh
+++ b/tools/automation/gitlab_deploy.sh
@@ -5,6 +5,7 @@ set -e -u -x
 rsync -rlv --include='*.tar.bz2' --exclude='*' $1/linux-64/ $2/linux-64/ # $BUILD_DIR $CHANNEL_DIR
 
 conda index $2 # $CHANNEL_DIR
+rm -r $2/linux-64/.cache
 
 aws s3 sync --acl public-read --acl bucket-owner-full-control --exclude '*/.cache/*' $2 $3 # $CHANNEL_DIR $CHANNEL_REM
 


### PR DESCRIPTION
Currently, the cache causes rsync errors the next time that the channel is copied to the conda artefacts directory (during the next automation run)