### PR TITLE
Change 'COMPARE_BRANCH' environment variables to include 'origin/' in automation yaml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,14 +18,14 @@ variables:
   PRE_DEVEL_CHANNEL_REM: s3://dnap/npg/conda/pre_devel/generic
   PRE_DEVEL_CHANNEL_DIR: /tmp/pre_devel/generic/
   PRE_DEVEL_BUILD_DIR: /tmp/conda_artefacts/pre_devel
-  PRE_DEVEL_COMPARE_BRANCH: devel
+  PRE_DEVEL_COMPARE_BRANCH: origin/devel
   #
   # devel commits
   #
   DEVEL_CHANNEL_REM: s3://dnap/npg/conda/devel/generic
   DEVEL_CHANNEL_DIR: /tmp/devel/generic/
   DEVEL_BUILD_DIR: /tmp/conda_artefacts/devel
-  DEVEL_COMPARE_BRANCH: master
+  DEVEL_COMPARE_BRANCH: origin/master
   #
   # TEST
   #


### PR DESCRIPTION
This fixes the error seen in https://gitlab.internal.sanger.ac.uk/npg/npg_conda/-/jobs/566892 where recipebook needs a remote to compare with.