### PR TITLE
Fix bugs in ldd tests during automation

### DIFF
--- a/automation/package.py
+++ b/automation/package.py
@@ -119,7 +119,9 @@ class Package:
                     libraries
             env: The conda environment in which to run ldd
         """
-        bin_ldd = run_command(Commands.RUN, '-n', env, 'ldd', path)
+        # '|| exit 0' prevents ldd from failing due to non executables
+        bin_ldd = run_command(Commands.RUN, '-n', env, 'ldd', path, '||',
+                              'exit', '0')
         for line in bin_ldd[0].split("\n"):
             if re.search(".*/usr/lib/.*", line):
                 if self.sub_packages():

--- a/bin/gitlab_test
+++ b/bin/gitlab_test
@@ -90,9 +90,9 @@ def test_descendant(changed_package: Package, descendant_package: Package,
 
     descendant_package.run_test_scripts(env)
 
-    changed_package.check_ldd(f'{os.environ["CONDA_DIR"]}envs/{env}/bin/*{env}',
+    changed_package.check_ldd(f'{os.environ["CONDA_DIR"]}/envs/{env}/bin/*',
                               env)
-    changed_package.check_ldd(f'{os.environ["CONDA_DIR"]}envs/{env}/lib/*{env}',
+    changed_package.check_ldd(f'{os.environ["CONDA_DIR"]}/envs/{env}/lib/*',
                               env)
 
 


### PR DESCRIPTION
Paths passed to ldd function had some errors.

The subprocess for ldd would fail due to the presence of non-executables.