### PR TITLE
Bugfix: target changed recipe files correctly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,15 @@
 from setuptools import setup, find_packages
 
 setup(name="npg_conda",
-      packages=find_packages('src'),
-      package_dir={'': 'src'},
+      packages=find_packages("src"),
+      package_dir={"": "src"},
       url="https://github.com/wtsi-npg/npg_conda",
       license="GPL3",
       author="Keith James, Michael Kubiak",
       author_email="kdj@sanger.ac.uk",
       description="Tools used to generate and maintain the npg conda channel",
       use_scm_version=True,
-      python_requires=">=3.8",
+      python_requires=">=3.9",
       setup_requires=[
               "setuptools_scm"
       ],


### PR DESCRIPTION
Set the cwd to the target directory when running git diff.

Filter any recipe files to accept only those under the target
directory.