### PR TITLE
Fix recipe paths returned by find_changed_recipe_files to be relative

### DIFF
--- a/src/recipebook/recipebook.py
+++ b/src/recipebook/recipebook.py
@@ -487,10 +487,9 @@ def find_changed_recipe_files(root: str, branch="master") -> List[str]:
         raise e
 
     files = [line.rstrip() for line in out.decode("utf-8").split("\n")]
-    dirs = list(set([Path(f).resolve().parent for f in files]))
-    dirs.sort()
+    dirs = sorted(set([Path(f).parent for f in files]))
 
-    recipe_dir = Path(root).resolve()
+    recipe_dir = Path(root)
     recipe_files = []
     for d in dirs:
         recipe = d / Path("meta.yaml")


### PR DESCRIPTION
This restores the original behaviour. Absolute paths were observed to
cause conda-build to fail (it tries to glob relative to a root
directory)..