### PR TITLE
Add "bash" to conda run_command call for tests.

### DIFF
--- a/src/automation/package.py
+++ b/src/automation/package.py
@@ -105,7 +105,7 @@ class Package:
         """
         ctx = conda.base.context.Context()
         if ctx.root_dir is None:
-           raise PackageError("Unable to locate the installed test scripts "
+            raise PackageError("Unable to locate the installed test scripts "
                                f"of {self} because Conda is not activated")
 
         conda_root = Path(ctx.root_dir)
@@ -116,13 +116,13 @@ class Package:
         if self.sub_packages():
             for sub in self.sub_packages():
                 scripts = list(conda_root.glob(
-                        glob_pattern.format(sub,self.version())))
+                    glob_pattern.format(sub, self.version())))
                 log.debug("Found {} test scripts "
                           "for {}".format(len(scripts), sub))
                 test_scripts.extend(scripts)
         else:
             scripts = list(conda_root.glob(
-                    glob_pattern.format(self.name(), self.version())))
+                glob_pattern.format(self.name(), self.version())))
             log.debug("Found {} test scripts "
                       "for {}".format(len(scripts), self.name()))
             test_scripts.extend(scripts)
@@ -143,7 +143,8 @@ class Package:
         failures = {}
 
         for script in test_scripts:
-            _, stderr, code = run_command(Commands.RUN, "-n", env, script)
+            _, stderr, code = run_command(Commands.RUN, "-n", env,
+                                          "/bin/bash", script)
             if code > 0:
                 failures[script] = stderr
 

--- a/tests/automation/fail
+++ b/tests/automation/fail
@@ -1,0 +1,2 @@
+#! /bin/bash
+exit 1

--- a/tests/automation/succeed
+++ b/tests/automation/succeed
@@ -1,0 +1,2 @@
+#! /bin/bash
+exit 0

--- a/tests/automation/test_package.py
+++ b/tests/automation/test_package.py
@@ -44,7 +44,7 @@ class TestPackage(object):
     def test_run_test_scripts_fail(self, test_recipebook, mocker):
         test_env = "base"  # We need a valid environment for the mock
         mocker.patch("automation.package.Package.get_test_scripts",
-                     return_value=["false"])  # /bin/false or equivalent
+                     return_value=["./tests/automation/fail"])
 
         with pytest.raises(FailedTestError):
             Package(("fail", "1.0.0"),
@@ -55,7 +55,7 @@ class TestPackage(object):
     def test_run_test_scripts_pass(self, test_recipebook, mocker):
         test_env = "base"  # We need a valid environment for the mock
         mocker.patch("automation.package.Package.get_test_scripts",
-                     return_value=["true"])  # /bin/true or equivalent
+                     return_value=["./tests/automation/succeed"])
 
         Package(("success", "1.0.0"),
                 recipebook=test_recipebook).run_test_scripts(test_env)


### PR DESCRIPTION
Conda's `run_test.sh` scripts are not executable, leading to
permission denied messages during automated testing.