### PR TITLE
Show worker ip

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,6 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: "Get public IP"
+        run: curl -s https://ipinfo.io/ip
+
       - name: "Initialize Miniconda"
         run: |
           echo 'source $CONDA/etc/profile.d/conda.sh' >> "$HOME/.bash_profile"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,6 +21,9 @@ jobs:
       - name: "Get public IP"
         run: curl -s https://ipinfo.io/ip
 
+      - name: "Get Azure instance info"
+        run: curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | cat | jq .
+
       - name: "Initialize Miniconda"
         run: |
           echo 'source $CONDA/etc/profile.d/conda.sh' >> "$HOME/.bash_profile"


### PR DESCRIPTION
@kjsanger I was trying to pull the IP from the worker to report the S3 pulling problems. I cannot find how to do it using github provided things. There are a couple of things in the github action markeplace thing, but I think is not worth bringing someone else's code for something like this.

So I can hack the think to get the public IP by making a request to a 'show me my ip' service. I tried pulling from Azure metadata of the instance itself. But seems they don't assign public IPs to these instances.

Do you think is worth cleaning things and merging to execute all the time. Or we just document so people find an example so we can make it easier to report things if we keep having issues with S3?