### PR TITLE
Pin the fmt dependency to a version <8.0

### DIFF
--- a/recipes/irods/4.2.11/meta.yaml
+++ b/recipes/irods/4.2.11/meta.yaml
@@ -11,7 +11,7 @@ about:
   summary: "Open Source Data Management Software."
 
 build:
-  number: 0
+  number: 1
 
 source:
   - git_url: https://github.com/irods/irods.git
@@ -42,7 +42,7 @@ requirements:
     - avrocpp-dev >=1.9
     - catch2
     - cppzmq
-    - fmt
+    - fmt <8.0
     - json
     - krb5-dev
     - libarchive-dev
@@ -59,7 +59,7 @@ outputs:
     version: {{ version }}
     requirements:
       run:
-        - fmt
+        - fmt <8.0
         - libarchive
         - libavrocpp >=1.9
         - libboost
@@ -97,7 +97,7 @@ outputs:
     requirements:
       run:
         - {{ pin_subpackage("irods-runtime", exact=True) }}
-        - fmt
+        - fmt <8.0
         - libarchive
         - libavrocpp >=1.9
         - libboost


### PR DESCRIPTION
The official iRODS externals package uses fmt 6.x. However, we've
successfully used 7.x. Recently the Conda defaults channel introduced
8.x, which is not compatible. This change pins it to a version <8.0