### PR TITLE
Add irmdir to the packaged executables for iRODS 4.2.11

### DIFF
--- a/recipes/irods/4.2.11/meta.yaml
+++ b/recipes/irods/4.2.11/meta.yaml
@@ -11,7 +11,7 @@ about:
   summary: "Open Source Data Management Software."
 
 build:
-  number: 2
+  number: 3
 
 source:
   - git_url: https://github.com/irods/irods.git
@@ -144,6 +144,7 @@ outputs:
       - bin/iquota
       - bin/irepl
       - bin/irm
+      - bin/irmdir
       - bin/irmtrash
       - bin/irsync
       - bin/irule


### PR DESCRIPTION
`irmdir` is a relatively recent addition to the icommands and was overlooked when creating this recipe.